### PR TITLE
Review: Add Communicator

### DIFF
--- a/pyleco/utils/communicator.py
+++ b/pyleco/utils/communicator.py
@@ -1,0 +1,247 @@
+#
+# This file is part of the PyLECO package.
+#
+# Copyright (c) 2023-2023 PyLECO Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import logging
+from time import perf_counter
+from typing import Any, Callable, Optional
+
+from jsonrpcobjects.errors import JSONRPCError
+import zmq
+
+from ..core import COORDINATOR_PORT
+from ..core.internal_protocols import CommunicatorProtocol
+from ..core.message import Message
+from ..core.rpc_generator import RPCGenerator, INVALID_SERVER_RESPONSE
+from ..errors import DUPLICATE_NAME, NOT_SIGNED_IN
+
+
+class Communicator(CommunicatorProtocol):
+    """A simple Communicator, which sends requests and reads the answer.
+
+    This Communicator does not listen for incoming messages. It only handles messages, whenever
+    you try to read one. It is intended for sending messages and reading the answer without
+    implementing threading.
+
+    The communicator can be used in a context, which ensures sign-in and sign-out:
+
+    .. code::
+
+        with Communicator(name="test") as com:
+            com.send("receiver")
+
+    :param str host: Hostname
+    :param int port: Port to connect to.
+    :param str name: Name to send messages as.
+    :param int timeout: Timeout in ms.
+    :param bool auto_open: Open automatically a connection upon instantiation.
+    :param str protocol: Protocol name to use.
+    :param bool standalone: Whether to bind to the port in standalone mode.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        host: str = "localhost",
+        port: Optional[int] = COORDINATOR_PORT,
+        timeout: int = 100,
+        auto_open: bool = True,
+        protocol: str = "tcp",
+        standalone: bool = False,
+        **kwargs,
+    ) -> None:
+        self.log = logging.getLogger(f"{__name__}.Communicator")
+        self.host = host
+        self.port = port
+        self._conn_details = protocol, standalone
+        self.timeout = timeout
+        self.log.info(f"Communicator initialized on {host}:{port}.")
+        if auto_open:
+            self.open()
+        self.name = name
+        self.namespace = None
+        self._last_beat: float = 0
+        self._reading: Optional[Callable[[], list[bytes]]] = None
+        self.rpc_generator = RPCGenerator()
+        super().__init__(**kwargs)
+
+    def open(self) -> None:
+        """Open the connection."""
+        context = zmq.Context.instance()
+        self.connection = context.socket(zmq.DEALER)
+        protocol, standalone = self._conn_details
+        if standalone:
+            self.connection.bind(f"{protocol}://*:{self.port}")
+        else:
+            self.connection.connect(f"{protocol}://{self.host}:{self.port}")
+
+    def close(self) -> None:
+        """Close the connection."""
+        try:
+            if not self.connection.closed:
+                self.sign_out()
+                self.connection.close(1)
+        except (AttributeError, TimeoutError):
+            pass
+
+    def reset(self) -> None:
+        """Reset socket"""
+        self.close()
+        self.open()
+
+    def __del__(self) -> None:
+        self.close()
+
+    def __enter__(self):  # -> typing.Self for py>=3.11
+        """Called with `with` keyword, returns the Director."""
+        if not hasattr(self, "connection"):
+            self.open()
+        self.sign_in()
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback) -> None:
+        """Called after the with clause has finished, does cleanup."""
+        self.close()
+
+    def retry_read(self, timeout: Optional[int] = None) -> list[bytes] | None:
+        """Retry reading."""
+        if self._reading and self.connection.poll(timeout or self.timeout):
+            return self._reading()
+        else:
+            return None
+
+    def send_message(self, message: Message) -> None:
+        now = perf_counter()
+        if now > self._last_beat + 15:
+            self.sign_in()
+        self._last_beat = now
+        if not message.sender:
+            message.sender = (".".join(
+                (self.namespace, self.name)) if self.namespace else self.name).encode()
+        frames = message.to_frames()
+        self.connection.send_multipart(frames)
+
+    def read_raw(self, timeout: Optional[int] = None) -> list[bytes]:
+        if self.connection.poll(timeout or self.timeout):
+            return self.connection.recv_multipart()
+        else:
+            self._reading = self.connection.recv_multipart
+            raise TimeoutError("Reading timed out.")
+
+    def poll(self) -> int:
+        """Check how many messages arrived."""
+        return self.connection.poll()
+
+    def read(self) -> Message:
+        return Message.from_frames(*self.read_raw())
+
+    def ask_raw(self, message: Message) -> Message:
+        """Send and read the answer, signing in if necessary."""
+        self.send_message(message=message)
+        cid = message.conversation_id
+        while True:
+            response = self.read()
+            # skip pings as we either are still signed in or going to sign in again.
+            if b"jsonrpc" in response.payload[0] and isinstance(response.data, dict):
+                if response.data.get("method") == "pong":
+                    continue
+                elif (error := response.data.get("error")):
+                    code = error.get("code")
+                    if code == NOT_SIGNED_IN.code:
+                        self.log.error("I'm not signed in, signing in.")
+                        self.sign_in()
+                        self.send_message(message=message)
+                        continue
+                    elif code == DUPLICATE_NAME.code:
+                        self.log.error(f"Sign in failed: {DUPLICATE_NAME.message}")
+                        raise ConnectionRefusedError(f"Sign in failed: {DUPLICATE_NAME.message}")
+            if cid == response.conversation_id:
+                return response
+            else:
+                self.log.warning(f"Message with different conversation id received: {response}.")
+
+    def ask_message(self, message: Message) -> Message:
+        """Send a message and retrieve the response."""
+        response = self.ask_raw(message=message)
+        if response.sender_elements.name == b"COORDINATOR":
+            try:
+                error = response.data.get("error")  # type: ignore
+            except AttributeError:
+                pass
+            else:
+                if error:
+                    # TODO define how to transmit that information
+                    raise ConnectionError(str(error))
+        return response
+
+    def ask_rpc(self, receiver: bytes | str, method: str, **kwargs) -> Any:
+        """Send a rpc call and return the result or raise an error."""
+        send_json = self.rpc_generator.build_request_str(method=method, **kwargs)
+        response_json = self.ask_json(receiver=receiver, json_string=send_json)
+        try:
+            result = self.rpc_generator.get_result_from_response(response_json)
+        except JSONRPCError as exc:
+            if exc.rpc_error.code == INVALID_SERVER_RESPONSE.code:
+                self.log.exception(f"Decoding failed for {response_json!r}.", exc_info=exc)
+                return
+            else:
+                self.log.exception(f"Some error happened {response_json!r}.", exc_info=exc)
+                raise
+        return result
+
+    def ask_json(self, receiver: bytes | str, json_string: str) -> bytes:
+        message = Message(receiver=receiver, data=json_string)
+        response = self.ask_message(message=message)
+        return response.payload[0]
+
+    # Messages
+    def sign_in(self) -> None:
+        """Sign in to the Coordinator and return the node."""
+        self.namespace = None
+        self._last_beat = perf_counter()  # to not sign in again...
+        json_string = self.rpc_generator.build_request_str(method="sign_in")
+        request = Message(receiver=b"COORDINATOR", data=json_string)
+        cid0 = request.conversation_id
+        response = self.ask_raw(message=request)
+        if b"error" in response.payload[0]:
+            raise ConnectionError
+        assert (
+            response.conversation_id == cid0
+        ), (f"Answer to another request (mine {cid0!r}) received from {response.sender!r}: "
+            f"{response.conversation_id!r}, '{response.data}'.")
+        self.namespace = response.sender_elements.namespace.decode()
+        self.log.info(f"Signed in to '{self.namespace}'.")
+
+    def sign_out(self) -> None:
+        """Tell the Coordinator to drop references."""
+        try:
+            self.ask_rpc(b"COORDINATOR", method="sign_out")
+        except JSONRPCError:
+            self.log.error("JSON decoding at sign out failed.")
+
+    def get_capabalities(self, receiver: bytes | str) -> dict:
+        return self.ask_rpc(receiver=receiver, method="rpc.discover")
+
+    def heartbeat(self) -> None:
+        """Send a heartbeat to the connected Coordinator."""
+        self.send_message(message=Message(receiver=b"COORDINATOR"))

--- a/tests/utils/test_communicator.py
+++ b/tests/utils/test_communicator.py
@@ -1,0 +1,176 @@
+#
+# This file is part of the PyLECO package.
+#
+# Copyright (c) 2023-2023 PyLECO Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyleco.core import VERSION_B
+from pyleco.core.message import Message
+from pyleco.errors import NOT_SIGNED_IN
+from pyleco.core.serialization import serialize_data
+
+from pyleco.utils.communicator import Communicator
+from pyleco.test import FakeSocket
+
+
+cid = b"conversation_id;"
+header = b"".join((cid, b"\x00" * 4))
+
+
+message_tests = (
+    ({'receiver': "broker", 'data': [["GET", [1, 2]], ["GET", 3]], 'sender': 's'},
+     [VERSION_B, b"broker", b"s", header, serialize_data([["GET", [1, 2]], ["GET", 3]])]),
+    ({'receiver': "someone", 'conversation_id': cid, 'sender': "ego", 'message_id': b"mid"},
+     [VERSION_B, b'someone', b'ego', b'conversation_id;mid\x00']),
+    ({'receiver': "router", 'sender': "origin"},
+     [VERSION_B, b"router", b"origin", header]),
+)
+
+
+def fake_time():
+    return 0
+
+
+def fake_randbytes(n):
+    return b"\01" * n
+
+
+def fake_generate_cid():
+    return cid
+
+
+@pytest.fixture()
+def fake_cid_generation(monkeypatch):
+    monkeypatch.setattr("pyleco.core.serialization.generate_conversation_id", fake_generate_cid)
+
+
+# intercom
+class FakeCommunicator(Communicator):
+    def open(self):
+        self.connection = FakeSocket(7)
+
+
+@pytest.fixture()
+def communicator() -> Communicator:
+    communicator = FakeCommunicator(name="Test")
+    communicator._last_beat = float("inf")
+    return communicator
+
+
+def test_name():
+    c = FakeCommunicator(name="Test")
+    assert c.name == "Test"
+
+
+def test_auto_open():
+    c = FakeCommunicator(name="Test", auto_open=True)
+    assert isinstance(c.connection, FakeSocket)
+
+
+def test_context_manager_opens_connection():
+    class FK2(FakeCommunicator):
+        def sign_in(self):
+            pass
+    with FK2(name="Test") as c:
+        assert isinstance(c.connection, FakeSocket)
+
+
+@pytest.mark.parametrize("kwargs, message", message_tests)
+def test_communicator_send(communicator: Communicator, kwargs, message, monkeypatch,
+                           fake_cid_generation):
+    monkeypatch.setattr("pyleco.utils.communicator.perf_counter", fake_time)
+    communicator.send(**kwargs)
+    assert communicator.connection._s.pop() == message  # type: ignore
+
+
+@pytest.mark.parametrize("kwargs, message", message_tests)
+def test_communicator_read(communicator: Communicator, kwargs, message):
+    communicator.connection._r.append(message)  # type: ignore
+    response = communicator.read()
+    assert response.receiver == kwargs.get('receiver').encode()
+    assert response.conversation_id == kwargs.get('conversation_id', cid)
+    assert response.sender == kwargs.get('sender', "").encode()
+    assert response.header_elements.message_id == kwargs.get('message_id', b"\x00\x00\x00")
+    assert response.data == kwargs.get("data")
+
+
+class Test_ask_raw:
+    request = Message(receiver=b"N1.receiver", data="whatever")
+    response = Message(receiver=b"N1.Test", sender=b"N1.receiver", data=["xyz"],
+                       conversation_id=request.conversation_id)
+
+    def test_ignore_ping(self, communicator: Communicator):
+        ping_message = Message(receiver=b"N1.Test", sender=b"N1.COORDINATOR",
+                               data={"id": 0, "method": "pong", "jsonrpc": "2.0"})
+        communicator.connection._r = [ping_message.to_frames(),
+                                      self.response.to_frames()]
+        communicator.ask_raw(self.request)
+        assert communicator.connection._s == [self.request.to_frames()]
+
+    def test_sign_in(self, communicator: Communicator):
+        communicator.sign_in = MagicMock()  # type: ignore
+        not_signed_in = Message(receiver="N1.Test", sender="N1.COORDINATOR",
+                                data={"id": None,
+                                      "error": NOT_SIGNED_IN.model_dump(),
+                                      "jsonrpc": "2.0"},
+                                )
+        communicator.connection._r = [not_signed_in.to_frames(),
+                                      self.response.to_frames()]
+        response = communicator.ask_raw(self.request)
+        print("result", response)
+        assert communicator.connection._s.pop(0) == self.request.to_frames()  # type: ignore
+        communicator.sign_in.assert_called()
+        assert communicator.connection._s == [self.request.to_frames()]
+
+    def test_ignore_wrong_response(self, communicator: Communicator,
+                                   caplog: pytest.LogCaptureFixture):
+        """A wrong response should not be returned."""
+        caplog.set_level(10)
+        m = Message(receiver="whatever", sender="s", data={'jsonrpc': "2.0"}).to_frames()
+        communicator.connection._r = [m, self.response.to_frames()]
+        assert communicator.ask_raw(self.request) == self.response
+        assert caplog.records[-1].msg.startswith("Message with different conversation id received:")
+
+
+def test_ask_rpc(communicator: Communicator, fake_cid_generation):
+    received = Message(receiver=b"N1.Test", sender=b"N1.receiver",
+                       conversation_id=cid)
+    received.payload = [b"""{"jsonrpc": "2.0", "result": 123.45, "id": "1"}"""]
+    communicator.connection._r = [received.to_frames()]
+    response = communicator.ask_rpc(receiver="N1.receiver", method="test_method", some_arg=4)
+    assert communicator.connection._s == [
+        [b'\x00', b'N1.receiver', b'Test', b'conversation_id;\x00\x00\x00\x00',
+         serialize_data({"id": 1, "method": "test_method",
+                         "params": {"some_arg": 4}, "jsonrpc": "2.0"})]]
+    assert response == 123.45
+
+
+def test_communicator_sign_in(fake_cid_generation, communicator: Communicator):
+    communicator.connection._r = [[
+        VERSION_B, b"N2.n", b"N2.COORDINATOR",
+        b"".join((cid, b"mid", b"0")),
+        serialize_data({"id": 1, "result": None, "jsonrpc": "2.0"})]]
+    communicator.sign_in()
+    assert communicator.namespace == "N2"


### PR DESCRIPTION
The `Communicator` is a simple utility to send messages via LECO and read the answer.

It does not run in another thread and does not interpret messages (not even ping requests), unless the `read` method is called.

The use case is for simple scripts, where you want to send a message and read the answer without the hassle to set up other threads etc.

In order to work, the `ask` method has to do some checks:

- If the Coordinator tells, that the Communicator is not signed in, it signs in and sends the message a second time
- All ping requests (from the Coordinator) since the last communication are dropped, as they are meaningless, since a new message has been sent.

For easier usage, the Communicator is a context manager (at enter it signs in, at exit it signs out).