### PR TITLE
Review: Add Message Handler

### DIFF
--- a/pyleco/core/data_message.py
+++ b/pyleco/core/data_message.py
@@ -1,0 +1,112 @@
+#
+# This file is part of the PyLECO package.
+#
+# Copyright (c) 2023-2023 PyLECO Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from json import JSONDecodeError
+from typing import Any, Optional, Union
+
+from .serialization import deserialize_data, generate_conversation_id, serialize_data, MessageTypes
+
+
+class DataMessage:
+    """A message of the data protocol."""
+
+    topic: bytes
+    header: bytes
+    payload: list[bytes]
+
+    def __init__(self,
+                 topic: Union[bytes, str],
+                 header: Optional[bytes] = None,
+                 data: Optional[Union[bytes, str, Any]] = None,
+                 conversation_id: Optional[bytes] = None,
+                 message_type: Union[MessageTypes, int] = MessageTypes.NOT_DEFINED,
+                 **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.topic = topic.encode() if isinstance(topic, str) else topic
+        if header and (conversation_id or message_type != MessageTypes.NOT_DEFINED):
+            raise ValueError(
+                "You may not specify the header and some header element at the same time!")
+        if header is None:
+            cid = generate_conversation_id() if conversation_id is None else conversation_id
+            self.header = cid + message_type.to_bytes(length=1, byteorder="big")
+        else:
+            self.header = header
+        if isinstance(data, bytes):
+            self.payload = [data]
+        elif isinstance(data, str):
+            self.payload = [data.encode()]
+        elif data is None:
+            self.payload = []
+        else:
+            self.payload = [serialize_data(data)]
+
+    @classmethod
+    def from_frames(cls, topic: bytes, header: bytes, *payload: bytes):
+        """Create a message from a frames list, for example after reading from a socket.
+
+        .. code::
+
+            frames = socket.recv_multipart()
+            message = DataMessage.from_frames(*frames)
+        """
+        message = cls(topic=topic, header=header)
+        message.payload = list(payload)
+        return message
+
+    def to_frames(self) -> list[bytes]:
+        return [self.topic, self.header] + self.payload
+
+    @property
+    def conversation_id(self) -> bytes:
+        return self.header[:-1]
+
+    @property
+    def message_type(self) -> int:
+        return self.header[-1]
+
+    @property
+    def data(self) -> object:
+        return deserialize_data(self.payload[0]) if self.payload else None
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, DataMessage):
+            return NotImplemented
+        partial_comparison = (
+            self.topic == other.topic
+            and self.header == other.header
+        )
+        try:
+            # Try to compare the data (python objects) instead of their bytes representation.
+            my_data = self.data
+            other_data = other.data
+        except JSONDecodeError:
+            # Maybe the payload is binary, compare the raw payload
+            return partial_comparison and self.payload == other.payload
+        else:
+            return (partial_comparison and my_data == other_data
+                    and self.payload[1:] == other.payload[1:])
+
+    def __repr__(self) -> str:
+        list_of_frames_strings = [str(frame) for frame in self.to_frames()]
+        return f"DataMessage.from_frames({', '.join(list_of_frames_strings)})"

--- a/pyleco/utils/data_publisher.py
+++ b/pyleco/utils/data_publisher.py
@@ -1,0 +1,120 @@
+#
+# This file is part of the PyLECO package.
+#
+# Copyright (c) 2023-2023 PyLECO Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import logging
+import pickle
+from typing import Any, Optional, Union
+
+import zmq
+
+from ..core import PROXY_RECEIVING_PORT
+from ..core.data_message import DataMessage, MessageTypes
+
+
+class DataPublisher:
+    """
+    Publishing data via the LECO data protocol.
+
+    :param str full_name: Name of the publishing Component
+    :param str address: Address of the server, default is localhost.
+    :param int port: Port of the server, defaults to 11100, default proxy.
+    :param log: Logger to log to.
+
+    Sending :class:`DataMessage` via the data protocol.
+
+    Quantities may be expressed as a (magnitude number, units str) tuple.
+    """
+
+    full_name: str
+
+    def __init__(self,
+                 full_name: str,
+                 host: str = "localhost",
+                 port: int = PROXY_RECEIVING_PORT,
+                 log: Optional[logging.Logger] = None,
+                 context: Optional[zmq.Context] = None,
+                 **kwargs) -> None:
+        if log is None:
+            self.log = logging.getLogger(f"{__name__}.Publisher")
+        else:
+            self.log = log.getChild("Publisher")
+        self.log.info(f"Publisher started at {host}:{port}.")
+        context = context or zmq.Context.instance()
+        self.socket: zmq.Socket = context.socket(zmq.PUB)
+        self.socket.connect(f"tcp://{host}:{port}")
+        self.full_name = full_name
+        super().__init__(**kwargs)
+
+    def __del__(self) -> None:
+        self.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback) -> None:
+        self.close()
+
+    def close(self) -> None:
+        self.socket.close(1)
+
+    def __call__(self, data: Any) -> None:
+        """Publish `data`."""
+        self.send_data(data=data)
+
+    def send_message(self, message: DataMessage) -> None:
+        """Send a data protocol message."""
+        self.socket.send_multipart(message.to_frames())
+
+    def send_data(self, data: Any,
+                  topic: Optional[Union[bytes, str]] = None,
+                  conversation_id: Optional[bytes] = None,
+                  message_type: Union[MessageTypes, int] = MessageTypes.NOT_DEFINED,
+                  ) -> None:
+        """Send the `data` via the data protocol."""
+        message = DataMessage(topic=topic or self.full_name,
+                              data=data,
+                              conversation_id=conversation_id,
+                              message_type=message_type
+                              )
+        self.send_message(message)
+
+    def send_legacy(self, data: dict[str, Any]) -> None:
+        for key, value in data.items():
+            # 234 is message type for legacy pickle: publish variable name as topic and pickle it
+            self.send_data(topic=key, data=pickle.dumps(value), message_type=234)
+
+    def set_full_name(self, full_name: str) -> None:
+        """Set the full name of the data publisher.
+
+        This method is useful for the listener's handler. That way a change of the listener's
+        name or namespace is transferred easily to the publisher as well.
+
+        .. code::
+
+            listener = Listener()
+            publisher = data_publisher(full_name=listener.full_name)
+            listener.message_handler.register_on_name_change_method(publisher.set_full_name)
+
+        """
+        self.full_name = full_name

--- a/pyleco/utils/events.py
+++ b/pyleco/utils/events.py
@@ -1,0 +1,44 @@
+#
+# This file is part of the PyLECO package.
+#
+# Copyright (c) 2023-2023 PyLECO Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from typing import Protocol
+
+
+class Event(Protocol):
+    """Check compatibility with threading.Event."""
+    def is_set(self) -> bool: ...  # pragma: no cover
+
+    def set(self) -> None: ...  # pragma: no cover
+
+
+class SimpleEvent(Event):
+    """A simple Event if the one from `threading` module is not necessary."""
+    def __init__(self) -> None:
+        self._flag = False
+
+    def is_set(self) -> bool:
+        return self._flag
+
+    def set(self) -> None:
+        self._flag = True

--- a/pyleco/utils/log_levels.py
+++ b/pyleco/utils/log_levels.py
@@ -1,0 +1,43 @@
+#
+# This file is part of the PyLECO package.
+#
+# Copyright (c) 2023-2023 PyLECO Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from enum import IntEnum
+import logging
+
+from ..core.leco_protocols import LogLevels
+
+
+class PythonLogLevels(IntEnum):
+    """Attribution of Python log levels to the LECO ones."""
+    DEBUG = logging.DEBUG
+    INFO = logging.INFO
+    WARNING = logging.WARNING
+    ERROR = logging.ERROR
+    CRITICAL = logging.CRITICAL
+
+
+def get_leco_log_level(log_level: int) -> LogLevels:
+    """Get the LECO log level from an integer (or python log level) if possible."""
+    name = PythonLogLevels(log_level).name
+    return LogLevels[name]

--- a/pyleco/utils/message_handler.py
+++ b/pyleco/utils/message_handler.py
@@ -1,0 +1,309 @@
+#
+# This file is part of the PyLECO package.
+#
+# Copyright (c) 2023-2023 PyLECO Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import logging
+import time
+from typing import Any, Callable, Optional
+
+from openrpc import RPCServer
+import zmq
+
+from ..core import COORDINATOR_PORT
+from ..core.leco_protocols import ExtendedComponentProtocol
+from ..core.message import Message
+from ..errors import NOT_SIGNED_IN, DUPLICATE_NAME
+from ..core.rpc_generator import RPCGenerator
+from ..core.serialization import generate_conversation_id
+from .log_levels import PythonLogLevels
+from .zmq_log_handler import ZmqLogHandler
+from .events import Event, SimpleEvent
+
+
+# Parameters
+heartbeat_interval = 10  # s
+
+
+class MessageHandler(ExtendedComponentProtocol):
+    """Maintain connection to the Coordinator and listen to incoming messages.
+
+    This class is inteded to run in a thread, maintain the connection to the coordinator
+    with heartbeats and timely responses. If a message arrives which is not connected to the control
+    protocol itself (e.g. ping message), another method is called.
+    You may subclass this class in order to handle these messages as desired.
+
+    You may use it as a context manager.
+
+    :param str name: Name to listen to and to publish values with.
+    :param str host: Host name (or IP address) of the Coordinator to connect to.
+    :param int port: Port number of the Coordinator to connect to.
+    :param protocol: Connection protocol.
+    :param log: Logger instance whose logs should be published. Defaults to `getLogger("__main__")`.
+    """
+    name: str
+    namespace: None | str
+
+    def __init__(self, name: str,
+                 host: str = "localhost", port: int = COORDINATOR_PORT, protocol: str = "tcp",
+                 log: Optional[logging.Logger] = None,
+                 context: Optional[zmq.Context] = None,
+                 **kwargs):
+        self.name = name
+        self.namespace: None | str = None
+        self.full_name = name
+        context = context or zmq.Context.instance()
+        self.rpc = RPCServer(title=name)
+        self.rpc_generator = RPCGenerator()
+        self.register_rpc_methods()
+
+        self._requests: dict[bytes, str] = {}
+        self.response_methods: dict[str, Callable] = {
+            "sign_in": self.handle_sign_in,
+            "sign_out": self.handle_sign_out
+        }
+
+        if log is None:
+            log = logging.getLogger("__main__")
+        # Add the ZmqLogHandler to the root logger, unless it has already a Handler.
+        first_pub_handler = True  # we expect to be the first ZmqLogHandler
+        for h in log.handlers:
+            if isinstance(h, ZmqLogHandler):
+                first_pub_handler = False
+                self.logHandler = h
+                break
+        if first_pub_handler:
+            self.logHandler = ZmqLogHandler()
+            log.addHandler(self.logHandler)
+        self.root_logger = log
+        self.log = self.root_logger.getChild("MessageHandler")
+
+        # ZMQ setup
+        self.socket: zmq.Socket = context.socket(zmq.DEALER)
+        self.log.info(f"MessageHandler connecting to {host}:{port}")
+        self.socket.connect(f"{protocol}://{host}:{port}")
+
+        super().__init__(**kwargs)  # for cooperation
+
+    def register_rpc_methods(self) -> None:
+        """Publish methods for RPC."""
+        self.rpc.method()(self.shut_down)
+        self.rpc.method()(self.set_log_level)
+        self.rpc.method()(self.pong)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Close the connection."""
+        self.socket.close(1)
+
+    # Base communication
+    def sign_in(self) -> None:
+        self._ask_rpc_async(b"COORDINATOR", method="sign_in")
+
+    def heartbeat(self) -> None:
+        """Send a heartbeat to the router."""
+        self.log.debug("heartbeat")
+        self._send_message(Message(b"COORDINATOR"))
+
+    def sign_out(self) -> None:
+        self._ask_rpc_async(b"COORDINATOR", method="sign_out")
+
+    def _send_message(self, message: Message) -> None:
+        """Send a message, supplying sender information."""
+        if not message.sender:
+            message.sender = self.full_name.encode()
+        frames = message.to_frames()
+        self.log.debug(f"Sending {frames}")
+        self.socket.send_multipart(frames)
+
+    def _send(self, receiver: bytes | str, sender: bytes | str = b"", data: Optional[Any] = None,
+              conversation_id: Optional[bytes] = None, **kwargs) -> None:
+        """Compose and send a message to a `receiver` with serializable `data`."""
+        try:
+            message = Message(receiver=receiver, sender=sender, data=data,
+                              conversation_id=conversation_id, **kwargs)
+        except Exception as exc:
+            self.log.exception(f"Composing message with data {data} failed.", exc_info=exc)
+            # TODO send an error message?
+        else:
+            self._send_message(message)
+
+    def _ask_rpc_async(self, receiver: bytes | str, method: str, **kwargs) -> None:
+        """Send a message and store the converation_id."""
+        cid = generate_conversation_id()
+        message = Message(receiver=receiver, conversation_id=cid,
+                          data=self.rpc_generator.build_request_str(method=method, **kwargs))
+        self._requests[cid] = method
+        self._send_message(message)
+
+    # User commands, implements Communicator
+    def send(self, receiver: bytes | str, data: Optional[Any] = None,
+             conversation_id: Optional[bytes] = None, **kwargs) -> None:
+        """Send a message to a receiver with serializable `data`."""
+        self._send(receiver=receiver, data=data, conversation_id=conversation_id, **kwargs)
+
+    def send_message(self, message: Message) -> None:
+        self._send_message(message)
+
+    # Continuous listening and message handling
+    def listen(self, stop_event: Event = SimpleEvent(), waiting_time: int = 100, **kwargs) -> None:
+        """Listen for zmq communication until `stop_event` is set or until KeyboardInterrupt.
+
+        :param stop_event: Event to stop the listening loop.
+        :param waiting_time: Time to wait for a readout signal in ms.
+        """
+        self.stop_event = stop_event
+        poller = self._listen_setup(**kwargs)
+        # Loop
+        try:
+            while not stop_event.is_set():
+                self._listen_loop_element(poller=poller, waiting_time=waiting_time)
+        except KeyboardInterrupt:
+            pass  # User stops the loop
+        except Exception:
+            raise
+        # Close
+        self._listen_close()
+
+    def _listen_setup(self) -> zmq.Poller:
+        """Setup for listening.
+
+        If you add your own sockets, remember to poll only for incoming messages.
+        """
+        self.log.info(f"Start to listen as '{self.name}'.")
+        # Prepare
+        poller = zmq.Poller()
+        poller.register(self.socket, zmq.POLLIN)
+
+        # open communication
+        self.sign_in()
+        self.next_beat = time.perf_counter() + heartbeat_interval
+        return poller
+
+    def _listen_loop_element(self, poller: zmq.Poller, waiting_time: int | None
+                             ) -> dict[zmq.Socket, int]:
+        """Check the socks for incoming messages and handle them.
+
+        :param waiting_time: Timeout of the poller in ms.
+        """
+        socks = dict(poller.poll(waiting_time))
+        if self.socket in socks:
+            self.handle_message()
+            del socks[self.socket]
+        elif (now := time.perf_counter()) > self.next_beat:
+            self.heartbeat()
+            self.next_beat = now + heartbeat_interval
+        return socks
+
+    def _listen_close(self) -> None:
+        """Close the listening loop."""
+        self.log.info(f"Stop listen as '{self.name}'.")
+        self.sign_out()
+        self.handle_message()
+
+    def handle_message(self) -> None:
+        """Interpret incoming message.
+
+        COORDINATOR messages are handled and then :meth:`handle_commands` does the rest.
+        """
+        msg = Message.from_frames(*self.socket.recv_multipart())
+        self.log.debug(f"Handling message {msg}")
+        if not msg.payload:
+            return
+        try:
+            if (msg.sender_elements.name == b"COORDINATOR"
+                    and (error := msg.data.get("error"))  # type: ignore
+                    and error.get("code") == NOT_SIGNED_IN.code):
+                self.namespace = None
+                self.set_full_name(self.name)
+                self.sign_in()
+                self.log.warning("I was not signed in, signing in.")
+                return
+            elif (method := self._requests.get(msg.conversation_id)):
+                self.handle_response(msg, method)
+                return
+        except AttributeError as exc:
+            self.log.exception(f"Message data {msg.data} misses an attribute!", exc_info=exc)
+        else:
+            self.handle_commands(msg)
+
+    def handle_response(self, message: Message, method: str):
+        del self._requests[message.conversation_id]
+        self.response_methods[method](message)
+
+    def handle_sign_in(self, message: Message) -> None:
+        if not isinstance(message.data, dict):
+            self.log.error(f"Not json message received: {message}")
+            return
+        if message.data.get("result", False) is None:
+            self.finish_sign_in(message)
+        elif (error := message.data.get("error")):
+            if error.get("code") == DUPLICATE_NAME.code:
+                self.log.warning("Sign in failed, the name is already used.")
+                return
+
+    def handle_sign_out(self, message: Message) -> None:
+        if isinstance(message.data, dict) and message.data.get("result", False) is None:
+            self.finish_sign_out(message)
+        else:
+            self.log.error(f"Signing out failed with {message}.")
+
+    def finish_sign_in(self, message: Message) -> None:
+        self.namespace = message.sender_elements.namespace.decode()
+        self.set_full_name(full_name=".".join((self.namespace, self.name)))
+        self.log.info(f"Signed in to Node '{self.namespace}'.")
+
+    def finish_sign_out(self, message: Message) -> None:
+        self.namespace = None
+        self.set_full_name(full_name=self.name)
+        self.log.info(f"Signed out from Node '{message.sender_elements.namespace.decode()}'.")
+
+    def set_full_name(self, full_name: str) -> None:
+        self.full_name = full_name
+        self.rpc.title = full_name
+        self.logHandler.fullname = self.full_name
+
+    def handle_commands(self, msg: Message) -> None:
+        """Handle the list of commands in the message."""
+        if msg.payload and b'"jsonrpc":' in msg.payload[0]:
+            if b'"method":' in msg.payload[0]:
+                self.log.info(f"Handling commands of  {msg}.")
+                reply = self.rpc.process_request(msg.payload[0])
+                response = Message(msg.sender, conversation_id=msg.conversation_id, data=reply)
+                self.send_message(response)
+            else:
+                self.log.error(f"Unknown message from {msg.sender!r} received: {msg.payload[0]!r}")
+        else:
+            self.log.warning(f"Unknown message from {msg.sender!r} received: '{msg.data}', {msg.payload!r}.")  # noqa: E501
+
+    def set_log_level(self, level: str) -> None:
+        """Set the log level."""
+        plevel = PythonLogLevels[level]
+        self.root_logger.setLevel(plevel)
+
+    def shut_down(self) -> None:
+        self.stop_event.set()

--- a/pyleco/utils/zmq_log_handler.py
+++ b/pyleco/utils/zmq_log_handler.py
@@ -1,0 +1,85 @@
+#
+# This file is part of the PyLECO package.
+#
+# Copyright (c) 2023-2023 PyLECO Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import json
+import logging
+from logging.handlers import QueueHandler
+import time
+from typing import Any, Optional
+
+import zmq
+
+from ..core import LOG_RECEIVING_PORT
+
+
+class ZmqLogHandler(QueueHandler):
+    """Handle log entries publishing them.
+
+    You have to set the :attr:`fullname` in order to publish logs.
+
+    :attr fullname: Full name of the Component.
+    """
+
+    fullname: str
+
+    def __init__(self, context: Optional[zmq.Context] = None, host: str = "localhost",
+                 port: int = LOG_RECEIVING_PORT, fullname: str = "") -> None:
+        context = context or zmq.Context.instance()
+        socket: zmq.Socket = context.socket(zmq.PUB)
+        socket.connect(f"tcp://{host}:{port}")
+        super().__init__(socket)  # type: ignore
+        self.fullname = fullname
+
+    def prepare(self, record: logging.LogRecord) -> list[str]:
+        """Prepare a json serializable message from the record in order to send it."""
+        record.message = record.getMessage()
+        record.asctime = time.strftime('%Y-%m-%d %H:%M:%S')
+        tmp = [record.asctime, str(record.levelname), str(record.name)]
+        s = self.format(record)
+        if record.exc_info:
+            # Cache the traceback text to avoid converting it multiple times
+            # (it's constant anyway)
+            if not record.exc_text:
+                record.exc_text = logging.Formatter.formatException(self, record.exc_info)  # type: ignore  # noqa: E501
+        if record.exc_text:
+            if s[-1:] != "\n":
+                s = s + "\n"
+            s = s + record.exc_text
+        if record.stack_info:
+            if s[-1:] != "\n":
+                s = s + "\n"
+            s = s + record.stack_info
+        tmp.append(s)
+        return tmp
+
+    def enqueue(self, record: Any) -> None:
+        """Enqueue a message prepared by :meth:`prepare`, if the fullname is given."""
+        # TODO adjust serialization according to protocol definition
+        try:
+            self.queue.send_multipart((self.fullname.encode(), json.dumps(record).encode()))  # type: ignore  # noqa: E501
+        except AttributeError:
+            pass
+
+    def close(self) -> None:
+        self.queue.close(1)  # type: ignore

--- a/tests/core/test_data_message.py
+++ b/tests/core/test_data_message.py
@@ -1,0 +1,136 @@
+#
+# This file is part of the PyLECO package.
+#
+# Copyright (c) 2023-2023 PyLECO Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import pytest
+
+from pyleco.core.data_message import DataMessage
+
+topic = b"N1.CA"
+cid = b"conversation_id;"
+message_type = 0
+
+
+@pytest.fixture
+def message():
+    message = DataMessage(topic, conversation_id=cid, data=[4, 5])
+    return message
+
+
+class TestDataMessageInit:
+    def test_topic(self, message: DataMessage):
+        assert message.topic == topic
+
+    def test_header(self, message: DataMessage):
+        assert message.header == cid + b"\x00"
+
+    def test_data(self, message: DataMessage):
+        assert message.data == [4, 5]
+
+    @pytest.mark.parametrize("key, value", (("conversation_id", b"content"),
+                                            ("message_type", 7),
+                                            ))
+    def test_header_param_incompatible_with_header_element_params(self, key, value):
+        with pytest.raises(ValueError, match="header"):
+            DataMessage(topic="topic", header=b"whatever", **{key: value})
+
+
+def test_data_message_str_topic():
+    assert DataMessage(topic="topic").topic == b"topic"
+
+
+def test_data_message_message_type():
+    message = DataMessage(topic=b"topic", message_type=7)
+    assert message.message_type == 7
+
+
+def test_converation_id(message: DataMessage):
+    assert message.conversation_id == cid
+
+
+def test_message_type(message: DataMessage):
+    assert message.message_type == 0
+
+
+class TestDataMessageData:
+    def test_bytes_payload(self):
+        message = DataMessage(b"", data=b"some data stuff")
+        assert message.payload == [b"some data stuff"]
+
+    def test_str_payload(self):
+        message = DataMessage(b"", data="some data stuff")
+        assert message.payload == [b"some data stuff"]
+
+    def test_no_payload(self):
+        message = DataMessage(b"")
+        assert message.payload == []
+
+
+class TestFromFrames:
+    @pytest.fixture
+    def from_frames_message(self):
+        message = DataMessage.from_frames(b"frame0", b"frame1", b"frame2", b"frame3")
+        return message
+
+    def test_topic(self, from_frames_message: DataMessage):
+        assert from_frames_message.topic == b"frame0"
+
+    def test_header(self, from_frames_message: DataMessage):
+        assert from_frames_message.header == b"frame1"
+
+    def test_payload(self, from_frames_message: DataMessage):
+        assert from_frames_message.payload == [b"frame2", b"frame3"]
+
+
+def test_to_frames():
+    message = DataMessage(b"topic", conversation_id=cid, data=b"data")
+    assert message.to_frames() == [b"topic", b"conversation_id;\x00", b"data"]
+
+
+class TestComparison:
+    def test_message_comparison(self):
+        frames = [b"topic", b"conversation_id;\x00", b'[["GET", [1, 2]]']
+        m1 = DataMessage.from_frames(*frames)
+        m2 = DataMessage.from_frames(*frames)
+        assert m1 == m2
+
+    def test_dictionary_order_is_irrelevant(self):
+        m1 = DataMessage(b"topic", conversation_id=cid, data={"a": 1, "b": 2})
+        m2 = DataMessage(b"topic", conversation_id=cid, data={"b": 2, "a": 1})
+        assert m1 == m2
+
+    def test_distinguish_empty_payload_frame(self):
+        m1 = DataMessage("r", conversation_id=b"conversation_id;")
+        m1.payload = [b""]
+        m2 = DataMessage("r", conversation_id=b"conversation_id;")
+        assert m2.payload == []  # verify that it does not have a payload
+        assert m1 != m2
+
+    @pytest.mark.parametrize("other", (5, 3.4, [64, 3], (5, "string"), "string"))
+    def test_comparison_with_something_else_fails(self, message, other):
+        assert message != other
+
+
+def test_repr():
+    message = DataMessage.from_frames(b'topic', b'conversation_id;\x00', b'data')
+    assert repr(message) == r"DataMessage.from_frames(b'topic', b'conversation_id;\x00', b'data')"

--- a/tests/utils/test_data_publisher.py
+++ b/tests/utils/test_data_publisher.py
@@ -1,0 +1,80 @@
+#
+# This file is part of the PyLECO package.
+#
+# Copyright (c) 2023-2023 PyLECO Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import pickle
+import pytest
+
+from pyleco.utils.data_publisher import DataPublisher, DataMessage
+from pyleco.test import FakeContext
+
+
+@pytest.fixture
+def publisher():
+    publisher = DataPublisher(full_name="sender", context=FakeContext())  # type: ignore
+    return publisher
+
+
+def test_socket_type(publisher: DataPublisher):
+    assert publisher.socket.socket_type == 1
+
+
+def test_connection():
+    publisher = DataPublisher(full_name="", host="localhost", port=12345,
+                              context=FakeContext())  # type: ignore
+    assert publisher.socket.addr == "tcp://localhost:12345"
+
+
+def test_context_manager_closes_connection():
+    with DataPublisher("", context=FakeContext()) as p:  # type: ignore
+        pass
+    assert p.socket.closed is True
+
+
+def test_call_publisher_sends(publisher: DataPublisher):
+    publisher(b"data")
+    # assert
+    message = DataMessage.from_frames(*publisher.socket._s.pop())  # type: ignore
+    assert message.topic == publisher.full_name.encode()
+    assert message.payload[0] == b"data"
+
+
+def test_send_message(publisher: DataPublisher):
+    message = DataMessage.from_frames(b"topic", b"header", b"data")
+    publisher.send_message(message=message)
+    assert publisher.socket._s == [message.to_frames()]
+
+
+def test_send_legacy(publisher: DataPublisher):
+    value = 5.67
+    publisher.send_legacy({'key': value})
+    message = DataMessage.from_frames(*publisher.socket._s[0])  # type: ignore
+    assert message.topic == b"key"
+    assert message.payload[0] == pickle.dumps(value)
+    assert message.message_type == 234
+
+
+def test_set_full_name(publisher: DataPublisher):
+    new_full_name = "new full name"
+    publisher.set_full_name(new_full_name)
+    assert publisher.full_name == new_full_name

--- a/tests/utils/test_log_levels.py
+++ b/tests/utils/test_log_levels.py
@@ -1,0 +1,49 @@
+#
+# This file is part of the PyLECO package.
+#
+# Copyright (c) 2023-2023 PyLECO Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import logging
+
+import pytest
+
+from pyleco.utils.log_levels import get_leco_log_level, LogLevels, PythonLogLevels
+
+
+@pytest.mark.parametrize("level, value", (
+    (logging.DEBUG, LogLevels.DEBUG),
+    (logging.INFO, LogLevels.INFO),
+    (logging.WARNING, LogLevels.WARNING),
+    (logging.ERROR, LogLevels.ERROR),
+    (logging.CRITICAL, LogLevels.CRITICAL),
+))
+def test_get_leco_log_level(level, value):
+    assert get_leco_log_level(level) == value
+
+
+def test_failing_get_leco_log_level():
+    with pytest.raises(ValueError):
+        get_leco_log_level(5)
+
+
+def test_PythonLogLevels():
+    assert PythonLogLevels["DEBUG"] == logging.DEBUG

--- a/tests/utils/test_message_handler.py
+++ b/tests/utils/test_message_handler.py
@@ -1,0 +1,213 @@
+#
+# This file is part of the PyLECO package.
+#
+# Copyright (c) 2023-2023 PyLECO Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pyleco.core import VERSION_B
+from pyleco.core.message import Message
+from pyleco.core.leco_protocols import ExtendedComponentProtocol, LogLevels
+from pyleco.core.serialization import serialize_data
+from pyleco.test import FakeContext
+from pyleco.errors import NOT_SIGNED_IN
+
+from pyleco.utils.message_handler import MessageHandler, SimpleEvent
+
+
+cid = b"conversation_id;"
+header = b"".join((cid, b"\x00" * 4))
+
+
+def fake_generate_cid():
+    return cid
+
+
+@pytest.fixture()
+def fake_cid_generation(monkeypatch):
+    monkeypatch.setattr("pyleco.core.serialization.generate_conversation_id", fake_generate_cid)
+
+
+@pytest.fixture()
+def handler() -> MessageHandler:
+    handler = MessageHandler(name="handler", context=FakeContext())  # type: ignore
+    handler.namespace = "N1"
+    handler.full_name = "N1.handler"
+    handler.stop_event = SimpleEvent()
+    return handler
+
+
+class TestProtocolImplemented:
+    protocol_methods = [m for m in dir(ExtendedComponentProtocol) if not m.startswith("_")]
+
+    def static_test_methods_are_present(self):
+        def testing(component: ExtendedComponentProtocol):
+            pass
+        testing(MessageHandler(name="test"))
+
+    @pytest.fixture
+    def component_methods(self, handler: MessageHandler):
+        response = handler.rpc.process_request(
+            '{"id": 1, "method": "rpc.discover", "jsonrpc": "2.0"}')
+        result = handler.rpc_generator.get_result_from_response(response)  # type: ignore
+        return result.get('methods')
+
+    @pytest.mark.parametrize("method", protocol_methods)
+    def test_method_is_available(self, component_methods, method):
+        for m in component_methods:
+            if m.get('name') == method:
+                return
+        raise AssertionError(f"Method {method} is not available.")
+
+
+def test_context_manager():
+    stored_handler = None
+    with MessageHandler(name="handler", context=FakeContext()) as handler:  # type: ignore
+        assert isinstance(handler, MessageHandler)  # assert enter
+        stored_handler = handler
+    assert stored_handler.socket.closed is True  # exit
+
+
+def test_finish_sign_in(handler: MessageHandler):
+    handler.finish_sign_in(message=Message(b"handler", b"N5.COORDINATOR", data={
+        "id": 10, "result": None, "jsonrpc": "2.0"}))
+    assert handler.namespace == "N5"
+    assert handler.full_name == "N5.handler"
+
+
+def test_finish_sign_out(handler: MessageHandler):
+    handler.finish_sign_out(message=Message(b"handler", b"N5.COORDINATOR", data={
+        "id": 10, "result": None, "jsonrpc": "2.0"}))
+    assert handler.namespace is None
+    assert handler.full_name == "handler"
+
+
+# test communication
+def test_send(handler: MessageHandler):
+    handler.send("N2.CB", conversation_id=cid, message_id=b"sen", data=[["TEST"]])
+    assert handler.socket._s == [[VERSION_B, b"N2.CB", b"N1.handler", b"conversation_id;sen\x00",
+                                  b'[["TEST"]]']]
+
+
+def test_heartbeat(handler: MessageHandler, fake_cid_generation):
+    handler.heartbeat()
+    assert handler.socket._s == [[VERSION_B, b"COORDINATOR", b"N1.handler", header]]
+
+
+def test_handle_message_ignores_heartbeats(handler: MessageHandler):
+    handler.handle_commands = MagicMock()  # type: ignore
+    # empty message of heartbeat
+    handler.socket._r = [[VERSION_B, b"N1.handler", b"whatever", b";"]]  # type: ignore
+    handler.handle_message()
+    handler.handle_commands.assert_not_called()
+
+
+@pytest.mark.parametrize("i, out", (
+    ([VERSION_B, b"N1.handler", b"N1.CB", b"conversation_id;mid;0",
+      serialize_data({"id": 5, "method": "shut_down", "jsonrpc": "2.0"})],
+     [VERSION_B, b"N1.CB", b"N1.handler", b"conversation_id;\x00\x00\x00\x00",
+      serialize_data({"id": 5, "result": None, "jsonrpc": "2.0"})]),
+))
+def test_handle_message(handler: MessageHandler, i, out):
+    handler.socket._r = [i]  # type: ignore
+    handler.handle_message()
+    for j in range(len(out)):
+        if j == 3:
+            continue  # reply adds timestamp
+        assert handler.socket._s[0][j] == out[j]  # type: ignore
+
+
+def test_handle_not_signed_in_message(handler: MessageHandler):
+    handler.sign_in = MagicMock()  # type: ignore
+    handler.socket._r = [Message(receiver="handler", sender="N1.COORDINATOR", data={  # type: ignore
+        "id": 5, "error": {"code": NOT_SIGNED_IN.code}
+    }).to_frames()]
+    handler.handle_message()
+    assert handler.namespace is None
+    handler.sign_in.assert_called_once()
+    assert handler.full_name == "handler"
+
+
+def test_handle_SIGNIN_message_response(handler: MessageHandler):
+    handler._requests[b"conversation_si;"] = "sign_in"
+    handler.socket._r = [Message(receiver=b"N3.handler", sender=b"N3.COORDINATOR",  # type: ignore
+                                 conversation_id=b"conversation_si;", data={
+                                     "id": 0, "result": None, "jsonrpc": "2.0",
+                                 }).to_frames()]
+    handler.namespace = None
+    handler.handle_message()
+    assert handler.namespace == "N3"
+
+
+def test_handle_ACK_does_not_change_Namespace(handler: MessageHandler):
+    """Test that an ACK does not change the Namespace, if it is already set."""
+    handler.socket._r = [[VERSION_B, b"N3.handler", b"N3.COORDINATOR", b";",  # type: ignore
+                          serialize_data({"id": 3, "result": None, "jsonrpc": "2.0"})]]
+    handler.namespace = "N1"
+    handler.handle_message()
+    assert handler.namespace == "N1"
+
+
+class Test_listen:
+    @pytest.fixture
+    def handler_l(self, handler):
+        event = SimpleEvent()
+        event.set()
+        handler.socket._r = [Message(
+            "handler", "COORDINATOR",
+            data={"id": 2, "result": None, "jsonrpc": "2.0"}).to_frames()]
+        handler.listen(stop_event=event)
+        return handler
+
+    def test_messages_are_sent(self, handler_l: MessageHandler):
+        cids = tuple(handler_l._requests.keys())
+        assert handler_l.socket._s == [
+            Message("COORDINATOR", "N1.handler", conversation_id=cids[0],
+                    data={"id": 1, "method": "sign_in", "jsonrpc": "2.0"}).to_frames(),
+            Message("COORDINATOR", "N1.handler", conversation_id=cids[1],
+                    data={"id": 2, "method": "sign_out", "jsonrpc": "2.0"}).to_frames(),
+        ]
+
+    def test_next_beat(self, handler_l: MessageHandler):
+        assert handler_l.next_beat > 0
+
+    def test_loop_element_changes_heartbeat(self, handler_l: MessageHandler):
+        class FakePoller:
+            def poll(self, timeout):
+                return {}
+        handler_l.next_beat = 0
+        # Act
+        handler_l._listen_loop_element(poller=FakePoller(), waiting_time=0)  # type: ignore
+        assert handler_l.next_beat > 0
+
+
+def test_set_log_level(handler: MessageHandler):
+    handler.set_log_level(LogLevels.ERROR)
+    assert handler.root_logger.level == 40  # logging.ERROR
+
+
+def test_shutdown(handler: MessageHandler):
+    handler.stop_event = SimpleEvent()
+    handler.shut_down()
+    assert handler.stop_event.is_set() is True

--- a/tests/utils/test_message_handler.py
+++ b/tests/utils/test_message_handler.py
@@ -22,16 +22,17 @@
 # THE SOFTWARE.
 #
 
+import logging
 from unittest.mock import MagicMock
 
 import pytest
 
 from pyleco.core import VERSION_B
-from pyleco.core.message import Message
+from pyleco.core.message import Message, MessageTypes
 from pyleco.core.leco_protocols import ExtendedComponentProtocol, LogLevels
 from pyleco.core.serialization import serialize_data
-from pyleco.test import FakeContext
-from pyleco.errors import NOT_SIGNED_IN
+from pyleco.test import FakeContext, FakePoller
+from pyleco.errors import NOT_SIGNED_IN, DUPLICATE_NAME
 
 from pyleco.utils.message_handler import MessageHandler, SimpleEvent
 
@@ -81,6 +82,16 @@ class TestProtocolImplemented:
         raise AssertionError(f"Method {method} is not available.")
 
 
+class Test_setup_logging:
+    def test(self, handler: MessageHandler):
+        logger = logging.getLogger("test")
+        logger.addHandler(logging.NullHandler())
+        handler.setup_logging(logger)
+        assert len(logger.handlers) == 2
+        assert handler.root_logger == logger
+        assert handler.log == logging.getLogger("test.MessageHandler")
+
+
 def test_context_manager():
     stored_handler = None
     with MessageHandler(name="handler", context=FakeContext()) as handler:  # type: ignore
@@ -90,24 +101,40 @@ def test_context_manager():
 
 
 def test_finish_sign_in(handler: MessageHandler):
-    handler.finish_sign_in(message=Message(b"handler", b"N5.COORDINATOR", data={
-        "id": 10, "result": None, "jsonrpc": "2.0"}))
+    handler.finish_sign_in(message=Message(b"handler", b"N5.COORDINATOR",
+                                           message_type=MessageTypes.JSON, data={
+                                               "id": 10, "result": None, "jsonrpc": "2.0"}))
     assert handler.namespace == "N5"
     assert handler.full_name == "N5.handler"
 
 
 def test_finish_sign_out(handler: MessageHandler):
-    handler.finish_sign_out(message=Message(b"handler", b"N5.COORDINATOR", data={
-        "id": 10, "result": None, "jsonrpc": "2.0"}))
+    handler.finish_sign_out(message=Message(b"handler", b"N5.COORDINATOR",
+                                            message_type=MessageTypes.JSON, data={
+                                                "id": 10, "result": None, "jsonrpc": "2.0"}))
     assert handler.namespace is None
     assert handler.full_name == "handler"
 
 
 # test communication
 def test_send(handler: MessageHandler):
-    handler.send("N2.CB", conversation_id=cid, message_id=b"sen", data=[["TEST"]])
-    assert handler.socket._s == [[VERSION_B, b"N2.CB", b"N1.handler", b"conversation_id;sen\x00",
+    handler.send("N2.CB", conversation_id=cid, message_id=b"sen", data=[["TEST"]],
+                 message_type=MessageTypes.JSON)
+    assert handler.socket._s == [[VERSION_B, b"N2.CB", b"N1.handler", b"conversation_id;sen\x01",
                                   b'[["TEST"]]']]
+
+
+def test_send_with_sender(handler: MessageHandler):
+    handler.send("N2.CB", sender="sender", conversation_id=cid, message_id=b"sen",
+                 data=[["TEST"]],
+                 message_type=MessageTypes.JSON)
+    assert handler.socket._s == [[VERSION_B, b"N2.CB", b"sender", b"conversation_id;sen\x01",
+                                  b'[["TEST"]]']]
+
+
+def test_send_message_raises_error(handler: MessageHandler, caplog: pytest.LogCaptureFixture):
+    handler.send(receiver=b"5", header=b"header", conversation_id=b"12345")
+    assert caplog.messages[-1].startswith("Composing message with")
 
 
 def test_heartbeat(handler: MessageHandler, fake_cid_generation):
@@ -124,7 +151,7 @@ def test_handle_message_ignores_heartbeats(handler: MessageHandler):
 
 
 @pytest.mark.parametrize("i, out", (
-    ([VERSION_B, b"N1.handler", b"N1.CB", b"conversation_id;mid;0",
+    ([VERSION_B, b"N1.handler", b"N1.CB", b"conversation_id;mid" + bytes((MessageTypes.JSON,)),
       serialize_data({"id": 5, "method": "shut_down", "jsonrpc": "2.0"})],
      [VERSION_B, b"N1.CB", b"N1.handler", b"conversation_id;\x00\x00\x00\x00",
       serialize_data({"id": 5, "result": None, "jsonrpc": "2.0"})]),
@@ -140,9 +167,10 @@ def test_handle_message(handler: MessageHandler, i, out):
 
 def test_handle_not_signed_in_message(handler: MessageHandler):
     handler.sign_in = MagicMock()  # type: ignore
-    handler.socket._r = [Message(receiver="handler", sender="N1.COORDINATOR", data={  # type: ignore
-        "id": 5, "error": {"code": NOT_SIGNED_IN.code}
-    }).to_frames()]
+    handler.socket._r = [Message(receiver="handler", sender="N1.COORDINATOR",  # type: ignore
+                                 message_type=MessageTypes.JSON,
+                                 data={"id": 5, "error": {"code": NOT_SIGNED_IN.code}}
+                                 ).to_frames()]
     handler.handle_message()
     assert handler.namespace is None
     handler.sign_in.assert_called_once()
@@ -152,7 +180,9 @@ def test_handle_not_signed_in_message(handler: MessageHandler):
 def test_handle_SIGNIN_message_response(handler: MessageHandler):
     handler._requests[b"conversation_si;"] = "sign_in"
     handler.socket._r = [Message(receiver=b"N3.handler", sender=b"N3.COORDINATOR",  # type: ignore
-                                 conversation_id=b"conversation_si;", data={
+                                 conversation_id=b"conversation_si;",
+                                 message_type=MessageTypes.JSON,
+                                 data={
                                      "id": 0, "result": None, "jsonrpc": "2.0",
                                  }).to_frames()]
     handler.namespace = None
@@ -162,21 +192,99 @@ def test_handle_SIGNIN_message_response(handler: MessageHandler):
 
 def test_handle_ACK_does_not_change_Namespace(handler: MessageHandler):
     """Test that an ACK does not change the Namespace, if it is already set."""
-    handler.socket._r = [[VERSION_B, b"N3.handler", b"N3.COORDINATOR", b";",  # type: ignore
-                          serialize_data({"id": 3, "result": None, "jsonrpc": "2.0"})]]
+    handler.socket._r = [Message(b"N3.handler", b"N3.COORDINATOR",  # type: ignore
+                                 message_type=MessageTypes.JSON,
+                                 data={"id": 3, "result": None, "jsonrpc": "2.0"}).to_frames()]
     handler.namespace = "N1"
     handler.handle_message()
     assert handler.namespace == "N1"
 
 
+def test_handle_corrupted_message(handler: MessageHandler, caplog: pytest.LogCaptureFixture):
+    handler.socket._r = [Message(b"N3.handler", b"N3.COORDINATOR",  # type: ignore
+                                 message_type=MessageTypes.JSON,
+                                 data=[]).to_frames()]
+    handler.handle_message()
+    assert caplog.records[-1].msg.startswith("Message data")
+
+
+class Test_HandleSignInResponses:
+    def test_not_valid_message(self, handler: MessageHandler, caplog: pytest.LogCaptureFixture):
+        message = Message("handler", "COORDINATOR", data=b"[]")
+        handler.handle_sign_in_response(message)
+        caplog.records[-1].msg.startswith("Not json message received:")
+
+    def test_sign_in_successful(self, handler: MessageHandler):
+        handler.namespace = None
+        message = Message("handler", "N3.COORDINATOR", message_type=MessageTypes.JSON, data={
+            "jsonrcpc": "2.0", "result": None, "id": 1,
+        })
+        handler.handle_sign_in_response(message)
+        assert handler.namespace == "N3"
+
+    def test_duplicate_name(self, handler: MessageHandler, caplog: pytest.LogCaptureFixture):
+        handler.namespace = None
+        message = Message("handler", "N3.COORDINATOR", message_type=MessageTypes.JSON, data={
+            "jsonrpc": "2.0", "error": {'code': DUPLICATE_NAME.code}, "id": 5
+        })
+        handler.handle_sign_in_response(message=message)
+        assert handler.namespace is None
+        assert caplog.records[-1].msg == "Sign in failed, the name is already used."
+
+    def test_handle_unknown_error(self, handler: MessageHandler, caplog: pytest.LogCaptureFixture):
+        handler.namespace = None
+        message = Message("handler", "N3.COORDINATOR", message_type=MessageTypes.JSON, data={
+            "jsonrpc": "2.0", "error": {'code': 123545, "message": "error_msg"}, "id": 5
+        })
+        handler.handle_sign_in_response(message=message)
+        assert handler.namespace is None
+        assert caplog.records[-1].msg.startswith("Sign in failed, unknown error")
+
+    def test_handle_invalid_message(self, handler: MessageHandler, caplog: pytest.LogCaptureFixture
+                                    ):
+        """Handle a message without result or error."""
+        handler.namespace = None
+        message = Message("handler", "N3.COORDINATOR", message_type=MessageTypes.JSON, data={
+            "jsonrpc": "2.0", "id": 5, "method": "some_method",
+        })
+        handler.handle_sign_in_response(message=message)
+        assert handler.namespace is None
+        assert caplog.records[-1].msg.startswith("Sign in failed, unexpected message.")
+
+
+def test_handle_sign_out_response(handler: MessageHandler):
+    handler.namespace = "N3"
+    message = Message("handler", "N3.COORDINATOR", message_type=MessageTypes.JSON, data={
+        "jsonrpc": "2.0", "result": None, "id": 1,
+    })
+    handler.handle_sign_out_response(message)
+    assert handler.namespace is None
+
+
+def test_handle_sign_out_response_fail(handler: MessageHandler, caplog: pytest.LogCaptureFixture):
+    handler.namespace = "N3"
+    message = Message("handler", "N3.COORDINATOR", message_type=MessageTypes.JSON, data={
+        "jsonrpc": "2.0", "error": {"code": 12345}, "id": 1,
+    })
+    handler.handle_sign_out_response(message)
+    assert handler.namespace is not None
+    assert caplog.messages[-1].startswith("Signing out failed with")
+
+
+def test_handle_unknown_message_type(handler: MessageHandler, caplog: pytest.LogCaptureFixture):
+    message = Message("handler", sender="sender", message_type=255)
+    handler.handle_commands(msg=message)
+    assert caplog.records[-1].message.startswith("Message from b'sender'")
+
+
 class Test_listen:
     @pytest.fixture
-    def handler_l(self, handler):
+    def handler_l(self, handler: MessageHandler):
         event = SimpleEvent()
         event.set()
-        handler.socket._r = [Message(
-            "handler", "COORDINATOR",
-            data={"id": 2, "result": None, "jsonrpc": "2.0"}).to_frames()]
+        handler.socket._r = [  # type: ignore
+            Message("handler", "COORDINATOR", message_type=MessageTypes.JSON,
+                    data={"id": 2, "result": None, "jsonrpc": "2.0"}).to_frames()]
         handler.listen(stop_event=event)
         return handler
 
@@ -184,8 +292,10 @@ class Test_listen:
         cids = tuple(handler_l._requests.keys())
         assert handler_l.socket._s == [
             Message("COORDINATOR", "N1.handler", conversation_id=cids[0],
+                    message_type=MessageTypes.JSON,
                     data={"id": 1, "method": "sign_in", "jsonrpc": "2.0"}).to_frames(),
             Message("COORDINATOR", "N1.handler", conversation_id=cids[1],
+                    message_type=MessageTypes.JSON,
                     data={"id": 2, "method": "sign_out", "jsonrpc": "2.0"}).to_frames(),
         ]
 
@@ -193,13 +303,54 @@ class Test_listen:
         assert handler_l.next_beat > 0
 
     def test_loop_element_changes_heartbeat(self, handler_l: MessageHandler):
-        class FakePoller:
-            def poll(self, timeout):
-                return {}
         handler_l.next_beat = 0
         # Act
         handler_l._listen_loop_element(poller=FakePoller(), waiting_time=0)  # type: ignore
         assert handler_l.next_beat > 0
+
+    def test_loop_element_does_not_change_heartbeat_if_short(self, handler_l: MessageHandler):
+        handler_l.next_beat = float("inf")
+        # Act
+        handler_l._listen_loop_element(poller=FakePoller(), waiting_time=0)  # type: ignore
+        assert handler_l.next_beat == float("inf")
+
+    def test_KeyboardInterrupt_in_loop(self, handler: MessageHandler):
+        def raise_error(poller, waiting_time):
+            raise KeyboardInterrupt
+        handler._listen_loop_element = raise_error  # type: ignore
+        handler.listen()
+        # assert that no error is raised and that the test does not hang
+
+
+def test_listen_loop_element(handler: MessageHandler):
+    poller = FakePoller()
+    poller.register(handler.socket)
+    handler.socket._r = [  # type: ignore
+        Message("Test", "COORDINATOR").to_frames()
+    ]
+    socks = handler._listen_loop_element(poller, 0)  # type: ignore
+    assert socks == {}
+
+
+class Test_listen_close:
+    @pytest.fixture
+    def handler_lc(self, handler: MessageHandler):
+        handler._listen_close(0)
+        return handler
+
+    def test_sign_out_sent(self, handler_lc: MessageHandler):
+        sent = Message.from_frames(*handler_lc.socket._s[-1])  # type: ignore
+        assert handler_lc.socket._s == [Message("COORDINATOR", "N1.handler",
+                                                conversation_id=sent.conversation_id,
+                                                message_type=MessageTypes.JSON,
+                                                data={
+                                                    "id": 1, "method": "sign_out", "jsonrpc": "2.0",
+                                                    },
+                                                ).to_frames()]
+
+    def test_warning_log_written(self, handler_lc: MessageHandler,
+                                 caplog: pytest.LogCaptureFixture):
+        assert caplog.get_records("setup")[-1].message == "Waiting for sign out response timed out."
 
 
 def test_set_log_level(handler: MessageHandler):

--- a/tests/utils/test_zmq_log_handler.py
+++ b/tests/utils/test_zmq_log_handler.py
@@ -1,0 +1,46 @@
+#
+# This file is part of the PyLECO package.
+#
+# Copyright (c) 2023-2023 PyLECO Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+import pytest
+
+from pyleco.test import FakeContext
+from pyleco.utils.zmq_log_handler import ZmqLogHandler
+
+
+@pytest.fixture
+def handler() -> ZmqLogHandler:
+    return ZmqLogHandler(context=FakeContext(), fullname="fullname", port=12345)  # type: ignore
+
+
+def test_init_(handler: ZmqLogHandler):
+    assert handler.fullname == "fullname"
+
+
+def test_init_address(handler: ZmqLogHandler):
+    assert handler.queue.addr == "tcp://localhost:12345"  # type: ignore
+
+
+def test_enqueue(handler: ZmqLogHandler):
+    handler.enqueue("whatever")
+    assert handler.queue._s == [[b"fullname", b'"whatever"']]  # type: ignore

--- a/tests/utils/test_zmq_log_handler.py
+++ b/tests/utils/test_zmq_log_handler.py
@@ -25,22 +25,24 @@
 import pytest
 
 from pyleco.test import FakeContext
-from pyleco.utils.zmq_log_handler import ZmqLogHandler
+from pyleco.utils.zmq_log_handler import ZmqLogHandler, DataMessage
 
 
 @pytest.fixture
 def handler() -> ZmqLogHandler:
-    return ZmqLogHandler(context=FakeContext(), fullname="fullname", port=12345)  # type: ignore
+    return ZmqLogHandler(context=FakeContext(), full_name="fullname", port=12345)  # type: ignore
 
 
 def test_init_(handler: ZmqLogHandler):
-    assert handler.fullname == "fullname"
+    assert handler.full_name == "fullname"
 
 
 def test_init_address(handler: ZmqLogHandler):
-    assert handler.queue.addr == "tcp://localhost:12345"  # type: ignore
+    assert handler.queue.socket.addr == "tcp://localhost:12345"  # type: ignore
 
 
 def test_enqueue(handler: ZmqLogHandler):
     handler.enqueue("whatever")
-    assert handler.queue._s == [[b"fullname", b'"whatever"']]  # type: ignore
+    message = DataMessage.from_frames(*handler.queue.socket._s.pop())  # type: ignore
+    assert message.topic == b"fullname"
+    assert message.payload == [b'whatever']


### PR DESCRIPTION
The `MessageHandler` is the base for single threaded LECO components: It listens in a continuous loop to incoming messages and handles them.

- It tries to sign-in whenever it is told, that it is not signed in.
- It handles ping messages.
- Designed for extension:
  - The continuous loop is divided in three parts: setup, loop-element, close, such that subclasses may change or expand these individual parts instead of writing everything again.
  - Message handling is divided in several steps, such that you can intervene, wherever needed.
  - You can add more methods to the `rpc-server` such that these messages are handled natively

The `MessageHandler` is an extended Component (with log level and shutdown).

As dependency, it needs the `ZmqLogHandler`, which is a logging Handler which publishes log messages via the data protocol (on the log ports).