### PR TITLE
Add coverage badge

### DIFF
--- a/.github/workflows/pyleco_CI.yml
+++ b/.github/workflows/pyleco_CI.yml
@@ -89,6 +89,7 @@ jobs:
       - name: Test for Coverage
         run: pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=pyleco | tee pytest-coverage.txt
       - name: Pytest Coverage Comment
+        id: coverageComment
         uses: MishaKav/pytest-coverage-comment@main
         with:
           pytest-coverage-path: ./pytest-coverage.txt
@@ -103,6 +104,32 @@ jobs:
           unique-id-for-comment: python3.8
           junitxml-path: ./pytest.xml
           junitxml-title: Coverage Summary
+      - name: Check output coverage
+        run: |
+          echo "Coverage Percantage - ${{ steps.coverageComment.outputs.coverage }}"
+          echo "Coverage Color - ${{ steps.coverageComment.outputs.color }}"
+          echo "Coverage Html - ${{ steps.coverageComment.outputs.coverageHtml }}"
+
+          echo "Coverage Warnings - ${{ steps.coverageComment.outputs.warnings }}"
+
+          echo "Coverage Errors - ${{ steps.coverageComment.outputs.errors }}"
+          echo "Coverage Failures - ${{ steps.coverageComment.outputs.failures }}"
+          echo "Coverage Skipped - ${{ steps.coverageComment.outputs.skipped }}"
+          echo "Coverage Tests - ${{ steps.coverageComment.outputs.tests }}"
+          echo "Coverage Time - ${{ steps.coverageComment.outputs.time }}"
+
+          echo "Not Success Test Info - ${{ steps.coverageComment.outputs.notSuccessTestInfo }}"
+
+      - name: Create the Badge
+        uses: schneegans/dynamic-badges-action@v1.6.0
+        with:
+          auth: ${{ secrets.pyleco_coverage_gist_secret }}
+          gistID: 7a8a7b874b62ed803eb56ca04830bede
+          filename: pyleco-coverage.json
+          label: Coverage Report
+          message: ${{ steps.coverageComment.outputs.coverage }}
+          color: ${{ steps.coverageComment.outputs.color }}
+          namedLogo: python
   test:
     name: Python ${{ matrix.python-version }}, ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
+![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/bmoneke/7a8a7b874b62ed803eb56ca04830bede/raw/pyleco-coverage.json)
+
 # PyLECO
 Python reference implementation of the Laboratory Experiment COntrol (LECO) protocol (https://github.com/pymeasure/leco-protocol).
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
-![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/bmoneke/7a8a7b874b62ed803eb56ca04830bede/raw/pyleco-coverage.json)
-
 # PyLECO
 Python reference implementation of the Laboratory Experiment COntrol (LECO) protocol (https://github.com/pymeasure/leco-protocol).
+
+The [main branch](https://github.com/pymeasure/pyleco/tree/main) contains reviewed code, which does not yet contain all necessary modules and classes.
+The most recent development is in the [development branch
+](https://github.com/pymeasure/pyleco/tree/development), which might contain commits of a broken state.
+The [stable-development branch](https://github.com/pymeasure/pyleco/tree/stable-development) contains a stable, working version of PyLECO.
+Follow that branch to have always working code (as far as possible), but following the ongoing development.
+
+Note: LECO is still under development, such that the code and API might change.
+
+![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/bmoneke/7a8a7b874b62ed803eb56ca04830bede/raw/pyleco-coverage.json)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Python reference implementation of the Laboratory Experiment COntrol (LECO) prot
 
 The [main branch](https://github.com/pymeasure/pyleco/tree/main) contains reviewed code, which does not yet contain all necessary modules and classes.
 The most recent development is in the [development branch
-](https://github.com/pymeasure/pyleco/tree/development), which might contain commits of a broken state.
+](https://github.com/pymeasure/pyleco/tree/development), which might contain commits with PyLECO being in a broken state.
 The [stable-development branch](https://github.com/pymeasure/pyleco/tree/stable-development) contains a stable, working version of PyLECO.
 Follow that branch to have always working code (as far as possible), but following the ongoing development.
 


### PR DESCRIPTION
Add a coverage badge to the readme file.

Note regarding implementation:
- That is the workflow of the coverage report: https://github.com/MishaKav/pytest-coverage-comment/blob/main/.github/workflows/live-test.yml
- https://github.com/marketplace/actions/dynamic-badges describes how to prepare everything for a dynamic badge (this is the dependency of pytest-coverage-comment): create a gist, make it public, create a secret for that gist, add it to the repository
- adjust the first script with the information of the second: gist id, file_name, secret name
- Important: You have to use the "githubusercontent" URL to work, see https://github.com/badges/shields/discussions/7435?sort=top