### PR TITLE
Fix ci, internal REPO

### DIFF
--- a/.github/workflows/pyleco_CI.yml
+++ b/.github/workflows/pyleco_CI.yml
@@ -69,8 +69,9 @@ jobs:
     name: Code Coverage
     runs-on: "ubuntu-latest"
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
+      issues: write
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
see #25 

now from the repo internally.

This PR adds write permission to contents, in order to write a coverage comment after a merge.