### PR TITLE
Add uploading CI workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,30 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Build and Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@v1.8.11

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,6 +11,7 @@ jobs:
   deploy:
 
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 


### PR DESCRIPTION
Add a workflow to upload a release to PyPI once it is published.

It requires to [add a publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) to PyPI, which seems to be the most recent authentication scheme.
@bilderbuchi , could you either add me (https://pypi.org/user/bburger/) as a maintainer to pyleco on pypi, or setup pypi to accept releases from github? This is simply to enter the owner name, the repo name, the file name ("python-publish.yml") and the environment name (not applicable yet).

That will make releases quite simple: Create changelog, make a github release, done.