### PR TITLE
Improve communicator and director

### DIFF
--- a/pyleco/core/internal_protocols.py
+++ b/pyleco/core/internal_protocols.py
@@ -86,12 +86,15 @@ class CommunicatorProtocol(Protocol):
             receiver=receiver, conversation_id=conversation_id, data=data, **kwargs),
             timeout=timeout)
 
+    def interpret_rpc_response(self, response_message: Message) -> Any:
+        return self.rpc_generator.get_result_from_response(response_message.payload[0])
+
     def ask_rpc(self, receiver: Union[bytes, str], method: str, timeout: Optional[float] = None,
                 **kwargs) -> Any:
         string = self.rpc_generator.build_request_str(method=method, **kwargs)
         response = self.ask(receiver=receiver, data=string, message_type=MessageTypes.JSON,
                             timeout=timeout)
-        return self.rpc_generator.get_result_from_response(response.payload[0])
+        return self.interpret_rpc_response(response)
 
 
 class SubscriberProtocol(Protocol):

--- a/pyleco/directors/director.py
+++ b/pyleco/directors/director.py
@@ -170,8 +170,14 @@ class Director:
 
     def ask_rpc_async(self, method: str, actor: Optional[Union[bytes, str]] = None,
                       **kwargs) -> bytes:
+        """Send a rpc request, the response can be read with :meth:`read_rpc_response`."""
         string = self.generator.build_request_str(method=method, **kwargs)
         return self.send(actor=actor, data=string, message_type=MessageTypes.JSON)
+
+    def read_rpc_response(self, conversation_id: Optional[bytes] = None, **kwargs) -> Any:
+        """Read the response value corresponding to a certain request."""
+        response_message = self.communicator.read_message(conversation_id=conversation_id, **kwargs)
+        return self.communicator.interpret_rpc_response(response_message=response_message)
 
     #   Actor
     def get_parameters_async(self, parameters: Union[str, Sequence[str]],

--- a/pyleco/directors/director.py
+++ b/pyleco/directors/director.py
@@ -112,11 +112,13 @@ class Director:
 
     # Remote control synced
     def ask_rpc(self, method: str, actor: Optional[Union[bytes, str]] = None, **kwargs) -> Any:
+        """Remotely call the `method` procedure on the `actor` and return the return value."""
         receiver = self._actor_check(actor)
         return self.communicator.ask_rpc(receiver=receiver, method=method, **kwargs)
 
     #   Component
     def get_rpc_capabilities(self, actor: Optional[Union[bytes, str]] = None) -> dict:
+        """Get a list of the remotely callable procedures of the actor."""
         return self.ask_rpc(method="rpc.discover", actor=actor)
 
     def shut_down_actor(self, actor: Optional[Union[bytes, str]] = None) -> None:
@@ -125,7 +127,7 @@ class Director:
 
     def set_actor_log_level(self, level: Union[str, int], actor: Optional[Union[bytes, str]] = None
                             ) -> None:
-        """Set the log level of the actor"""
+        """Set the log level of the actor."""
         if isinstance(level, int):
             level = get_leco_log_level(level).value
         self.ask_rpc("set_log_level", level=level, actor=actor)
@@ -170,19 +172,22 @@ class Director:
 
     def ask_rpc_async(self, method: str, actor: Optional[Union[bytes, str]] = None,
                       **kwargs) -> bytes:
-        """Send a rpc request, the response can be read with :meth:`read_rpc_response`."""
+        """Send a rpc request, the response can be read later with :meth:`read_rpc_response`."""
         string = self.generator.build_request_str(method=method, **kwargs)
         return self.send(actor=actor, data=string, message_type=MessageTypes.JSON)
 
     def read_rpc_response(self, conversation_id: Optional[bytes] = None, **kwargs) -> Any:
-        """Read the response value corresponding to a certain request."""
+        """Read the response value corresponding to a request with a certain `conversation_id`."""
         response_message = self.communicator.read_message(conversation_id=conversation_id, **kwargs)
         return self.communicator.interpret_rpc_response(response_message=response_message)
 
     #   Actor
     def get_parameters_async(self, parameters: Union[str, Sequence[str]],
                              actor: Optional[Union[bytes, str]] = None) -> bytes:
-        """Request the values of these `properties` (list, tuple) and return the conversation_id."""
+        """Request the values of these `properties` (list, tuple) and return the conversation_id.
+
+        You can use :meth:`read_rpc_response` to read the response.
+        """
         if isinstance(parameters, str):
             parameters = (parameters,)
         # return self.send(data=[[Commands.GET, properties]])
@@ -190,13 +195,18 @@ class Director:
 
     def set_parameters_async(self, parameters: dict[str, Any],
                              actor: Optional[Union[bytes, str]] = None) -> bytes:
-        """Set the `properties` dictionary and return the conversation_id."""
+        """Set the `properties` dictionary and return the conversation_id.
+
+        You can use :meth:`read_rpc_response` to read the response.
+        """
         # return self.send(data=[[Commands.SET, properties]])
         return self.ask_rpc_async(method="set_parameters", parameters=parameters, actor=actor)
 
     def call_action_async(self, action: str, *args, actor: Optional[Union[bytes, str]] = None,
                           **kwargs) -> bytes:
         """Call a method remotely and return the conversation_id.
+
+        You can use :meth:`read_rpc_response` to read the response.
 
         :param str action: Name of the action to call.
         :param \\*args: Arguments for the action to call.

--- a/pyleco/utils/communicator.py
+++ b/pyleco/utils/communicator.py
@@ -163,10 +163,6 @@ class Communicator(CommunicatorProtocol):
         # TODO add filtering for conversation_id (with the MessageBuffer?)
         return Message.from_frames(*self.read_raw(timeout=timeout))
 
-    def read(self) -> Message:
-        # deprecated
-        return Message.from_frames(*self.read_raw())
-
     def ask_raw(self, message: Message, timeout: Optional[float] = None) -> Message:
         """Send and read the answer, signing in if necessary."""
         self.send_message(message=message)

--- a/pyleco/utils/communicator.py
+++ b/pyleco/utils/communicator.py
@@ -211,7 +211,7 @@ class Communicator(CommunicatorProtocol):
         response = self.ask(receiver=receiver, data=send_json, timeout=timeout,
                             message_type=MessageTypes.JSON)
         try:
-            result = self.rpc_generator.get_result_from_response(response.payload[0])
+            result = self.interpret_rpc_response(response)
         except JSONRPCError as exc:
             if exc.rpc_error.code == INVALID_SERVER_RESPONSE.code:
                 self.log.exception(f"Decoding failed for {response.payload[0]!r}.", exc_info=exc)

--- a/pyleco/utils/coordinator_utils.py
+++ b/pyleco/utils/coordinator_utils.py
@@ -307,11 +307,6 @@ class Directory:
         elif isinstance(data, dict) and (error := data.get("error") is not None):
             log.error(f"Coordinator sign in to node {message.sender_elements.namespace!r} failed with '{error}'.")  # noqa: E501
             self._remove_waiting_node(key=key)
-        # TODO this is only useful, if we read the DEALER sockets regularly
-        # elif data == [[Commands.ERROR, Errors.NOT_SIGNED_IN]]:
-        #     # Somehow connection got lost, sign in again
-        #     sock.send_multipart(create_message(receiver=b"COORDINATOR", sender=self.fname,
-        #                                        payload=serialize_data([[Commands.CO_SIGNIN]])))
         else:
             log.warning(
                 f"Unknown message {message.payload!r} from {message.sender!r} at DEALER socket '{key}'.")  # noqa: E501

--- a/pyleco/utils/pipe_handler.py
+++ b/pyleco/utils/pipe_handler.py
@@ -200,8 +200,7 @@ class CommunicatorPipe(CommunicatorProtocol, SubscriberProtocol):
 
     def _read_handler(self, cid: bytes, timeout: float = 1) -> Any:
         response_message = self.read_message(conversation_id=cid, timeout=timeout)
-        result = self.rpc_generator.get_result_from_response(response_message.payload[0])
-        return result
+        return self.interpret_rpc_response(response_message=response_message)
 
     def ask_handler(self, method: str, timeout: float = 1, **kwargs) -> Any:
         """Ask the associated message handler."""

--- a/tests/core/test_internal_protocols.py
+++ b/tests/core/test_internal_protocols.py
@@ -24,6 +24,8 @@
 
 import pytest
 
+from jsonrpcobjects.errors import JSONRPCError
+
 from pyleco.core.message import Message, MessageTypes
 from pyleco.core.internal_protocols import CommunicatorProtocol
 from pyleco.test import FakeCommunicator
@@ -70,6 +72,18 @@ class Test_ask:
     def test_read(self, communicator_asked: FakeCommunicator):
         response = communicator_asked.ask(receiver="rec", conversation_id=cid)
         assert response == self.response
+
+
+class Test_interpret_rpc_response:
+    def test_valid_message(self, communicator: FakeCommunicator):
+        message = Message(receiver="rec", data={"jsonrpc": "2.0", "result": 6.0, "id": 7})
+        assert communicator.interpret_rpc_response(message) == 6.0
+
+    def test_error(self, communicator: FakeCommunicator):
+        message = Message(receiver="rec", data={"jsonrpc": "2.0",
+                                                "error": {"code": -1, "message": "abc"}, "id": 7})
+        with pytest.raises(JSONRPCError):
+            communicator.interpret_rpc_response(message)
 
 
 class Test_ask_rpc:

--- a/tests/directors/test_director.py
+++ b/tests/directors/test_director.py
@@ -64,8 +64,9 @@ def test_context_manager():
     assert communicator._closed is True  # type: ignore
 
 
-class ActorCheck:
+class Test_actor_check:
     def test_invalid_actor(self, director: Director):
+        director.actor = None
         with pytest.raises(ValueError):
             director._actor_check(actor=None)
 
@@ -86,6 +87,14 @@ def test_shutdown_actor(director: Director):
         Message("actor", "director", conversation_id=cid, message_type=MessageTypes.JSON, data={
             "id": 1, "method": "shut_down", "jsonrpc": "2.0"
             })]
+
+
+def test_read_rpc_response(director: Director):
+    director.communicator._r = [  # type: ignore
+        Message("director", "actor", conversation_id=cid, message_type=MessageTypes.JSON, data={
+            "id": 1, "result": 7.5, "jsonrpc": "2.0"
+            })]
+    assert director.read_rpc_response(conversation_id=cid) == 7.5
 
 
 def test_get_properties_async(director: Director):

--- a/tests/utils/test_communicator.py
+++ b/tests/utils/test_communicator.py
@@ -139,17 +139,6 @@ def test_communicator_send(communicator: Communicator, kwargs, message, monkeypa
     assert communicator.connection._s.pop() == message  # type: ignore
 
 
-@pytest.mark.parametrize("kwargs, message", message_tests)
-def test_communicator_read(communicator: Communicator, kwargs, message):
-    communicator.connection._r.append(message)  # type: ignore
-    response = communicator.read()
-    assert response.receiver == kwargs.get('receiver').encode()
-    assert response.conversation_id == kwargs.get('conversation_id', cid)
-    assert response.sender == kwargs.get('sender', "").encode()
-    assert response.header_elements.message_id == kwargs.get('message_id', b"\x00\x00\x00")
-    assert response.data == kwargs.get("data")
-
-
 class Test_ask_raw:
     request = Message(receiver=b"N1.receiver", data="whatever")
     response = Message(receiver=b"N1.Test", sender=b"N1.receiver", data=["xyz"],


### PR DESCRIPTION
The `interpret_rpc_response` of the CommunicatorProtocol and the `read_rpc_response` of the Director are quality of life improvements, which skip the step of calling objects of other objects.


Additionally removal of some older code.