### PR TITLE
Fix DataLogger to start a timer, even if not specified explicitly.

### DIFF
--- a/pyleco/management/data_logger.py
+++ b/pyleco/management/data_logger.py
@@ -232,14 +232,17 @@ class DataLogger(ExtendedMessageHandler):
         self.stop_collecting()
         log.info(f"Start collecting data. Trigger: {trigger_type}, {trigger_timeout}, "
                  f"{trigger_variable}; subscriptions: {variables}")
+        self.today = datetime.datetime.now(datetime.timezone.utc).date()
         self.trigger_type = trigger_type or self._last_trigger_type
         self._last_trigger_type = self.trigger_type
-        self.trigger_variable = self.trigger_variable if trigger_variable is None else trigger_variable  # noqa
-        self.trigger_timeout = self.trigger_timeout if trigger_timeout is None else trigger_timeout
-        if trigger_type == TriggerTypes.TIMER:
+        if self.trigger_type == TriggerTypes.TIMER:
             self.start_timer_trigger()
-        self.value_repeating = self.value_repeating if value_repeating is None else value_repeating
-        self.today = datetime.datetime.now(datetime.timezone.utc).date()
+        if trigger_timeout is not None:
+            self.trigger_timeout = trigger_timeout
+        if trigger_variable is not None:
+            self.trigger_variable = trigger_variable
+        if value_repeating is not None:
+            self.value_repeating = value_repeating
         self.set_valuing_mode(valuing_mode=valuing_mode)
         self.setup_variables(self.lists.keys() if variables is None else variables)
         self.units = units if units else {}

--- a/tests/management/test_data_logger.py
+++ b/tests/management/test_data_logger.py
@@ -88,6 +88,21 @@ def test_start_collecting_starts_timer(data_logger: DataLogger):
     data_logger.timer.cancel()
 
 
+def test_start_collecting_starts_timer_even_second_time(data_logger: DataLogger):
+    """Even a second time, without explicit trigger type, the timer should be started."""
+    # arrange
+    data_logger.trigger_timeout = 1000
+    data_logger.start_collecting(trigger_type=TriggerTypes.TIMER)  # first time, to set type
+    data_logger.stop_collecting()
+    assert not hasattr(data_logger, "timer")  # no timer left
+    # act
+    data_logger.start_collecting()
+    # assert
+    assert data_logger.timer.interval == 1000
+    # cleanup
+    data_logger.timer.cancel()
+
+
 def test_listen_close_stops_collecting(data_logger: DataLogger):
     data_logger.stop_collecting = MagicMock()  # type: ignore[method-assign]
     # act


### PR DESCRIPTION
The DataLogger did not start a new timer, if it is not specified explicitly.

A test verifies the behavior and passes with this fix.