### PR TITLE
Add coordinators and starter as executable scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - **Breaking:** change PipeHandler inner workings of handling messages.
 - Add `BaseCommunicator` as a base class for Communicator and MessageHandler (#48)
 
+### Added
+
+- Add the `Coordinator`, the `proxy_server`, and the `starter` as scripts to the command line
+
 ### Removed
 
 - **Breaking:** remove `Coordinator.ask_raw` (#48)

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -19,8 +19,9 @@ As LECO consists in two parts, the control protocol and the data protocol, there
 1. The _Coordinator_ in [`coordinator.py`](pyleco/coordinators/coordinator.py) is the server of the control protocol.
 2. [`proxy_server.py`](pyleco/coordinators/proxy_server.py) contains the server of the data protocol.
 
-In order to start these Coordinators, just execute the files with python.
-For example, change directory in the folder of this file and execute `python3 pyleco/coordinators/coordinator.py` under linux or `py pyleco/coordinators/coordinator.py` under Windows with the Windows Launcher installed.
+In order to start these Coordinators, execute `coordinator` and `proxy_server` in a terminal.
+Alternatively, execute the corresponding files with python:
+for example, change directory in the folder of this getting started file and execute `python3 pyleco/coordinators/coordinator.py` under linux or `py pyleco/coordinators/coordinator.py` under Windows with the Windows Launcher installed.
 
 If you need settings which are different from the defaults, you can use command line parameters.
 The command line parameter `-h` or `--help` gives an overview of all available parameters.
@@ -37,7 +38,8 @@ It will start, if told to do so, the method `task` of a given file name in a sep
 That allows to specify several different tasks, for example each one controlling one measurement instrument, and to start them by sending a command to the starter.
 How this works exactly, is described below. 
 
-In order to start the starter itself, just execute its file with the path to the directory, for example `python3 pyleco/management/starter.py --directory ~/tasks` with the tasks being in the subfolder `tasks` of the home directory.
+In order to start the starter itself, execute `starter --directory ~/tasks` in a terminal with the tasks being in the subfolder `tasks` of the home directory.
+Alternatively, execute its file with the path to the directory, for example `python3 pyleco/management/starter.py --directory ~/tasks`. 
 
 #### Define a Task File
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For that purpose, you send a message which encodes exactly that (via jsonrpc): t
 ### Minimum Setup
 
 For a minimum setup, you need:
-* a Coordinator (just run `coordinator.py` file)
+* a Coordinator (just execute `coordinator` in your terminal or run the `coordinator.py` file with your Python interpreter)
 * one Component
 
 For example, you can use a `Communicator` instance to send/receive messages via LECO protocol.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,11 @@ dev = [
 "Homepage" = "https://github.com/pymeasure/pyleco"
 "Bug Tracker" = "https://github.com/pymeasure/pyleco/issues"
 
+[project.scripts]
+coordinator = "pyleco.coordinators.coordinator:main"
+proxy_server = "pyleco.coordinators.proxy_server:main"
+starter = "pyleco.management.starter:main"
+
 [build-system]
 requires = ["setuptools>=61.0", "wheel", "setuptools_scm>=7.0"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This allows to easily start the main infrastructure without need to locate the files in the python installation.