### PR TITLE
Reorganize json objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,18 @@ _Use self defined objects instead of jsonrpc2-objects and jsonrpc2-pyclient._
 
 - Rename `cls` parameter to `device_class` in `Actor` and `TransparentDirector`.
 - Substitute `jsonrpc2-objects` and `jsonrpc2-pyclient` by self written objects.
+- Move error definitions from `pyleco.errors` to `pyleco.json_utils.errors`.
+- Move `pyleco.errors.CommunicationError` to `pyleco.json_utils.errors`.
+- Deprecate `generate_error_with_data` in favor of `DataError.from_error` class method.
 - Python requirement lowered to Python 3.8
 
 ### Added
 
 - Add __future__.annotations to all files, which need it for annotations for Python 3.7/3.8.
 - Add self written `RPCServer` as alternative to openrpc package.
+
+### Deprecated
+- Deprecate `pyleco.errors` in favor of `json_utils.errors` and `json_utils.json_objects`.
 
 
 ## [0.2.2] - 2024-02-14

--- a/pyleco/coordinators/coordinator.py
+++ b/pyleco/coordinators/coordinator.py
@@ -292,7 +292,7 @@ class Coordinator:
         try:
             receiver_identity = self.directory.get_component_id(name=receiver_name)
         except ValueError:
-            log.error(f"Receiver '{message.receiver}' is not in the addresses list.")
+            log.error(f"Receiver '{message.receiver!r}' is not in the addresses list.")
             error = DataError.from_error(RECEIVER_UNKNOWN, data=message.receiver.decode())
             self.send_message(
                 receiver=message.sender,

--- a/pyleco/json_utils/errors.py
+++ b/pyleco/json_utils/errors.py
@@ -1,39 +1,63 @@
-"""This module provides exceptions for each JSON-RPC 2.0 error.
+#
+# This file is part of the PyLECO package.
+#
+# Copyright (c) 2023-2024 PyLECO Developers
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+"""
+Based on jsonrpc2-objects
+
+This module provides exceptions for each JSON-RPC 2.0 error.
 
 There is one Exception defined for each pre-defined JSON-RPC 2.0 error.
 Additionally, there is a ServerError for implementation-defined errors.
 
 Each exception extends a base exception JSONRPCError.
-
-Copied from jsonrpc2-objects
 """
 
-__all__ = (
-    "INTERNAL_ERROR",
-    "INVALID_PARAMS",
-    "INVALID_REQUEST",
-    "InternalError",
-    "InvalidParams",
-    "InvalidRequest",
-    "JSONRPCError",
-    "METHOD_NOT_FOUND",
-    "MethodNotFound",
-    "PARSE_ERROR",
-    "ParseError",
-    "ServerError",
-    "get_exception_by_code",
-)
 
 from typing import Optional, Type
 
 from .json_objects import DataError, Error, ErrorType
 
-SERVER_ERROR = Error(code=-32000, message="Server error")
+# JSONRPC 2.0 defined errors
 INVALID_REQUEST = Error(code=-32600, message="Invalid Request")
 METHOD_NOT_FOUND = Error(code=-32601, message="Method not found")
 INVALID_PARAMS = Error(code=-32602, message="Invalid params")
 INTERNAL_ERROR = Error(code=-32603, message="Internal error")
 PARSE_ERROR = Error(code=-32700, message="Parse error")
+
+# -32000 to -32099  Server error    reserved for implementation-defined server-errors
+# general error: -32000
+SERVER_ERROR = Error(code=-32000, message="Server error")
+
+# LECO defined errors
+# Routing errors (Coordinator) between -32090 and -32099
+NOT_SIGNED_IN = Error(code=-32090, message="You did not sign in!")
+DUPLICATE_NAME = Error(code=-32091, message="The name is already taken.")
+NODE_UNKNOWN = Error(code=-32092, message="Node is not known.")
+RECEIVER_UNKNOWN = Error(code=-32093, message="Receiver is not in addresses list.")
+
+# Error during deserialization error of the server's response
+INVALID_SERVER_RESPONSE = Error(code=-32000, message="Invalid response from server.")
 
 
 class JSONRPCError(Exception):
@@ -44,49 +68,49 @@ class JSONRPCError(Exception):
         self.rpc_error = error
         if isinstance(error, DataError):
             msg += f"\nError Data: {error.data}"
-        super(JSONRPCError, self).__init__(msg)
+        super().__init__(msg)
 
 
 class ParseError(JSONRPCError):
     """Error raised when invalid JSON was received by the server."""
 
     def __init__(self, error: Optional[ErrorType] = None) -> None:
-        super(ParseError, self).__init__(error or PARSE_ERROR)
+        super().__init__(error or PARSE_ERROR)
 
 
 class InvalidRequest(JSONRPCError):
     """Error raised when the JSON sent is not a valid Request object."""
 
     def __init__(self, error: Optional[ErrorType] = None) -> None:
-        super(InvalidRequest, self).__init__(error or INVALID_REQUEST)
+        super().__init__(error or INVALID_REQUEST)
 
 
 class MethodNotFound(JSONRPCError):
     """Error raised when the method does not exist / is not available."""
 
     def __init__(self, error: Optional[ErrorType] = None) -> None:
-        super(MethodNotFound, self).__init__(error or METHOD_NOT_FOUND)
+        super().__init__(error or METHOD_NOT_FOUND)
 
 
 class InvalidParams(JSONRPCError):
     """Error raised when invalid method parameter(s) are supplied."""
 
     def __init__(self, error: Optional[ErrorType] = None) -> None:
-        super(InvalidParams, self).__init__(error or INVALID_PARAMS)
+        super().__init__(error or INVALID_PARAMS)
 
 
 class InternalError(JSONRPCError):
     """Error raised when there is an internal JSON-RPC error."""
 
     def __init__(self, error: Optional[ErrorType] = None) -> None:
-        super(InternalError, self).__init__(error or INTERNAL_ERROR)
+        super().__init__(error or INTERNAL_ERROR)
 
 
 class ServerError(JSONRPCError):
     """Error raised when a server error occurs."""
 
     def __init__(self, error: ErrorType) -> None:
-        super(ServerError, self).__init__(error)
+        super().__init__(error)
 
 
 def get_exception_by_code(code: int) -> Optional[Type[JSONRPCError]]:

--- a/pyleco/json_utils/json_objects.py
+++ b/pyleco/json_utils/json_objects.py
@@ -113,6 +113,10 @@ class DataError(JsonObject):
     message: str
     data: Any
 
+    @classmethod
+    def from_error(cls, error: Error, data: Any) -> DataError:
+        return cls(code=error.code, message=error.message, data=data)
+
 
 @dataclass
 class ErrorResponse(JsonObject):

--- a/pyleco/json_utils/rpc_generator.py
+++ b/pyleco/json_utils/rpc_generator.py
@@ -28,13 +28,10 @@ import logging
 from typing import Any, Union
 
 from .json_objects import Request, ParamsRequest, DataError, Error, ResultResponse
-from .errors import ServerError, get_exception_by_code, JSONRPCError
+from .errors import ServerError, get_exception_by_code, JSONRPCError, INVALID_SERVER_RESPONSE
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
-
-
-INVALID_SERVER_RESPONSE = Error(code=-32000, message="Invalid response from server.")
 
 
 class RPCGenerator:
@@ -59,7 +56,7 @@ class RPCGenerator:
 
     def get_result_from_response(self, data: Union[bytes, str, dict]) -> Any:
         """Get the result of that object or raise an error."""
-        # copied and modified from jsonrpc2-pyclient
+        # copied from jsonrpc2-pyclient and modified
         try:
             # Parse string to JSON.
             if not isinstance(data, dict):

--- a/pyleco/json_utils/rpc_server_definition.py
+++ b/pyleco/json_utils/rpc_server_definition.py
@@ -28,8 +28,7 @@ import logging
 from typing import Any, Callable, Optional, Union
 
 from .errors import INTERNAL_ERROR, SERVER_ERROR, INVALID_REQUEST
-from .json_objects import ResultResponse, ErrorResponse
-from ..errors import generate_error_with_data
+from .json_objects import ResultResponse, ErrorResponse, DataError
 
 
 log = logging.getLogger(__name__)
@@ -87,7 +86,7 @@ class RPCServer:
             else:
                 return ErrorResponse(
                     id=None,
-                    error=generate_error_with_data(INVALID_REQUEST, json_data),
+                    error=DataError.from_error(INVALID_REQUEST, json_data),
                 ).model_dump_json()
         except Exception as exc:
             log.exception(f"{type(exc).__name__}:", exc_info=exc)
@@ -102,7 +101,7 @@ class RPCServer:
             method_name = request.get("method")
             if method_name is None:
                 return ErrorResponse(
-                    id=id_, error=generate_error_with_data(INVALID_REQUEST, data=request)
+                    id=id_, error=DataError.from_error(INVALID_REQUEST, data=request)
                 )
             params = request.get("params")
             method = self._rpc_methods[method_name]

--- a/pyleco/utils/base_communicator.py
+++ b/pyleco/utils/base_communicator.py
@@ -31,8 +31,7 @@ import zmq
 
 from ..core.internal_protocols import CommunicatorProtocol
 from ..core.message import Message, MessageTypes
-from ..errors import DUPLICATE_NAME, NOT_SIGNED_IN
-from ..json_utils.errors import JSONRPCError
+from ..json_utils.errors import JSONRPCError, DUPLICATE_NAME, NOT_SIGNED_IN
 
 
 NOT_SIGNED_IN_ERROR_CODE = str(NOT_SIGNED_IN.code).encode()

--- a/pyleco/utils/communicator.py
+++ b/pyleco/utils/communicator.py
@@ -29,10 +29,10 @@ from typing import Optional, Union
 
 import zmq
 
-from ..errors import NOT_SIGNED_IN
 from ..core import COORDINATOR_PORT
 from ..core.message import Message, MessageTypes
 from ..json_utils.rpc_generator import RPCGenerator
+from ..json_utils.errors import NOT_SIGNED_IN
 from .base_communicator import BaseCommunicator
 
 

--- a/pyleco/utils/coordinator_utils.py
+++ b/pyleco/utils/coordinator_utils.py
@@ -27,20 +27,28 @@ from abc import abstractmethod
 from dataclasses import dataclass
 import logging
 from time import perf_counter
-from typing import Protocol, Optional, Union
+from typing import Any, Protocol, Optional, Union
 
 import zmq
 
 from ..core import COORDINATOR_PORT
-from ..errors import CommunicationError, NOT_SIGNED_IN, DUPLICATE_NAME
 from ..core.message import Message, MessageTypes
 from ..core.serialization import deserialize_data
+from ..json_utils.errors import NOT_SIGNED_IN, DUPLICATE_NAME
 from ..json_utils.rpc_generator import RPCGenerator
 from ..json_utils.json_objects import ErrorResponse, Request
 
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
+
+
+class CommunicationError(ConnectionError):
+    """Something went wrong, send an `error_msg` to the recipient."""
+
+    def __init__(self, text: str, error_payload: ErrorResponse, *args: Any) -> None:
+        super().__init__(text, *args)
+        self.error_payload = error_payload
 
 
 class MultiSocket(Protocol):

--- a/tests/coordinators/test_coordinator.py
+++ b/tests/coordinators/test_coordinator.py
@@ -27,9 +27,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from pyleco.json_utils.json_objects import Request, ErrorResponse
-from pyleco.errors import (NODE_UNKNOWN, NOT_SIGNED_IN, DUPLICATE_NAME, RECEIVER_UNKNOWN,
-                           generate_error_with_data)
+from pyleco.json_utils.json_objects import Request, ErrorResponse, DataError
+from pyleco.json_utils.errors import NODE_UNKNOWN, NOT_SIGNED_IN, DUPLICATE_NAME, RECEIVER_UNKNOWN
 from pyleco.core import VERSION_B
 from pyleco.core.message import Message, MessageTypes
 from pyleco.core.leco_protocols import ExtendedComponentProtocol, Protocol, CoordinatorProtocol
@@ -250,14 +249,14 @@ def test_reading_fails(coordinator: Coordinator, caplog: pytest.LogCaptureFixtur
     ([b"321", VERSION_B, b"x", b"send", b"conversation_id;mid0", b""],
      [b"321", VERSION_B, b"send", b"N1.COORDINATOR", b"conversation_id;\x00\x00\x00\x01",
       ErrorResponse(id=None,
-                    error=generate_error_with_data(RECEIVER_UNKNOWN,
-                                                   "x")).model_dump_json().encode()]),
+                    error=DataError.from_error(RECEIVER_UNKNOWN,
+                                               "x")).model_dump_json().encode()]),
     # unknown receiver node:
     ([b"321", VERSION_B, b"N3.CB", b"N1.send", b"conversation_id;mid0"],
      [b"321", VERSION_B, b"N1.send", b"N1.COORDINATOR", b"conversation_id;\x00\x00\x00\x01",
       ErrorResponse(id=None,
-                    error=generate_error_with_data(NODE_UNKNOWN,
-                                                   "N3")).model_dump_json().encode()]),
+                    error=DataError.from_error(NODE_UNKNOWN,
+                                               "N3")).model_dump_json().encode()]),
     # sender (without namespace) did not sign in:
     ([b"1", VERSION_B, b"rec", b"unknownSender", b"conversation_id;mid0"],
      [b"1", VERSION_B, b"unknownSender", b"N1.COORDINATOR", b"conversation_id;\x00\x00\x00\x01",

--- a/tests/json_utils/test_errors.py
+++ b/tests/json_utils/test_errors.py
@@ -22,34 +22,12 @@
 # THE SOFTWARE.
 #
 
-from typing import Any
-from warnings import warn
-
-from .json_utils.json_objects import Error, DataError, ErrorResponse
-
-from .json_utils.errors import NOT_SIGNED_IN, DUPLICATE_NAME, NODE_UNKNOWN, RECEIVER_UNKNOWN  # noqa
+from pyleco.json_utils.json_objects import Error
+from pyleco.json_utils.errors import JSONRPCError
 
 
-warn("The `pyleco.errors` module is deprecated, use the objects from the `pyleco.json_utils` "
-     "subpackage instead.", FutureWarning)
-
-
-def generate_error_with_data(error: Error, data: Any) -> DataError:
-    """Generate a DataError from an Error.
-
-    .. deprecated:: 0.3
-        Use `DataError.from_error` instead.
-    """
-    return DataError.from_error(error=error, data=data)
-
-
-class CommunicationError(ConnectionError):
-    """Something went wrong, send an `error_msg` to the recipient.
-
-    .. deprecated:: 0.3
-        Use the definition in `communicator_utils` module instead.
-    """
-
-    def __init__(self, text: str, error_payload: ErrorResponse, *args: Any) -> None:
-        super().__init__(text, *args)
-        self.error_payload = error_payload
+def test_JsonRPCError():
+    error = Error(5, "abc")
+    exc = JSONRPCError(error)
+    assert exc.rpc_error == error
+    assert exc.args[0] == "5: abc"

--- a/tests/json_utils/test_json_objects.py
+++ b/tests/json_utils/test_json_objects.py
@@ -75,3 +75,11 @@ def test_error_with_data():
     data_error = json_objects.DataError(code=5, message="whatever", data="abc")
     error_response = json_objects.ErrorResponse(id=7, error=data_error)
     assert error_response.model_dump_json() == '{"id":7,"error":{"code":5,"message":"whatever","data":"abc"},"jsonrpc":"2.0"}'  # noqa
+
+
+def test_generate_data_error_from_error():
+    error = json_objects.Error(code=5, message="abc")
+    data_error = json_objects.DataError.from_error(error, "data")
+    assert data_error.code == error.code
+    assert data_error.message == error.message
+    assert data_error.data == "data"

--- a/tests/json_utils/test_rpc_generator.py
+++ b/tests/json_utils/test_rpc_generator.py
@@ -27,9 +27,9 @@ from typing import Union
 import pytest
 
 from pyleco.json_utils.json_objects import ErrorResponse
-from pyleco.json_utils.errors import JSONRPCError
+from pyleco.json_utils.errors import (JSONRPCError, NODE_UNKNOWN, NOT_SIGNED_IN, DUPLICATE_NAME,
+                                      RECEIVER_UNKNOWN)
 
-from pyleco.errors import NODE_UNKNOWN, NOT_SIGNED_IN, DUPLICATE_NAME, RECEIVER_UNKNOWN
 from pyleco.json_utils.rpc_generator import RPCGenerator, INVALID_SERVER_RESPONSE
 
 

--- a/tests/utils/test_base_communicator.py
+++ b/tests/utils/test_base_communicator.py
@@ -33,7 +33,8 @@ import pytest
 from pyleco.test import FakeSocket
 from pyleco.core.message import Message, MessageTypes
 from pyleco.json_utils.rpc_generator import RPCGenerator
-from pyleco.errors import DUPLICATE_NAME, ErrorResponse
+from pyleco.json_utils.errors import DUPLICATE_NAME
+from pyleco.json_utils.json_objects import ErrorResponse
 
 from pyleco.utils.base_communicator import BaseCommunicator
 

--- a/tests/utils/test_communicator.py
+++ b/tests/utils/test_communicator.py
@@ -28,9 +28,8 @@ import pytest
 
 from pyleco.core import VERSION_B
 from pyleco.core.message import Message, MessageTypes
-from pyleco.errors import NOT_SIGNED_IN, NODE_UNKNOWN
 from pyleco.core.serialization import serialize_data
-from pyleco.json_utils.errors import JSONRPCError
+from pyleco.json_utils.errors import JSONRPCError, NOT_SIGNED_IN, NODE_UNKNOWN
 
 from pyleco.utils.communicator import Communicator
 from pyleco.test import FakeSocket, FakeContext

--- a/tests/utils/test_coordinator_utils.py
+++ b/tests/utils/test_coordinator_utils.py
@@ -26,9 +26,10 @@ import pytest
 
 from pyleco.test import FakeContext
 from pyleco.core.message import Message, MessageTypes
-from pyleco.errors import CommunicationError, NOT_SIGNED_IN, DUPLICATE_NAME
-from pyleco.utils.coordinator_utils import ZmqNode, ZmqMultiSocket, Node, Directory, FakeNode
+from pyleco.json_utils.errors import NOT_SIGNED_IN, DUPLICATE_NAME
 from pyleco.json_utils.json_objects import Request, ResultResponse, ErrorResponse
+from pyleco.utils.coordinator_utils import CommunicationError, ZmqNode, ZmqMultiSocket, Node,\
+    Directory, FakeNode
 
 
 class TestZmqMultiSocket:

--- a/tests/utils/test_message_handler.py
+++ b/tests/utils/test_message_handler.py
@@ -36,9 +36,9 @@ from pyleco.core.leco_protocols import ExtendedComponentProtocol, LogLevels
 from pyleco.core.internal_protocols import CommunicatorProtocol
 from pyleco.core.serialization import serialize_data
 from pyleco.test import FakeContext, FakePoller
-from pyleco.errors import NOT_SIGNED_IN, DUPLICATE_NAME, NODE_UNKNOWN, RECEIVER_UNKNOWN
 from pyleco.json_utils.json_objects import Request, ResultResponse, ErrorResponse
-from pyleco.json_utils.errors import JSONRPCError, INVALID_REQUEST
+from pyleco.json_utils.errors import JSONRPCError, INVALID_REQUEST, NOT_SIGNED_IN, DUPLICATE_NAME,\
+    NODE_UNKNOWN, RECEIVER_UNKNOWN
 
 from pyleco.utils.message_handler import MessageHandler, SimpleEvent
 


### PR DESCRIPTION
Now that we have our own json-objects and errors file, we can put all errors (even the LECO ones and the pyleco `INVALID_SERVER_RESPONSE`) into one file instead of keeping errors distributed over several files (errors, json_utils.errors, rpc_generator).