### PR TITLE
Fix Coordinator to not use period in hostname as namespace

### DIFF
--- a/pyleco/coordinators/coordinator.py
+++ b/pyleco/coordinators/coordinator.py
@@ -95,7 +95,7 @@ class Coordinator:
         **kwargs,
     ) -> None:
         if namespace is None:
-            self.namespace = gethostname().encode()
+            self.namespace = gethostname().split(".")[0].encode()
         elif isinstance(namespace, str):
             self.namespace = namespace.encode()
         elif isinstance(namespace, bytes):


### PR DESCRIPTION
Coordinator did turn the full hostname (including periods, for example "hostname.domain.tld") into the namespace.
A namespace must not contain periods.
This PR adds tests (which failed even where `gethostname` returns just the last name) and a fix covered by these tests.