### PR TITLE
Add binary payload handling to PyLECO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## [unreleased]
+
+### Added
+
+* Add convenience functions for using additional frames for binary payload ([#82](https://github.com/pymeasure/pyleco/pull/82))
+
+
 ## [0.3.2] 2024-5-07
 
 ### Fixed

--- a/pyleco/core/internal_protocols.py
+++ b/pyleco/core/internal_protocols.py
@@ -59,33 +59,44 @@ class CommunicatorProtocol(Protocol):
 
     def send_message(self, message: Message) -> None: ...  # pragma: no cover
 
-    def read_message(self, conversation_id: Optional[bytes], timeout: Optional[float] = None
-                     ) -> Message: ...  # pragma: no cover
+    def read_message(
+        self, conversation_id: Optional[bytes], timeout: Optional[float] = None
+    ) -> Message: ...  # pragma: no cover
 
-    def ask_message(self, message: Message, timeout: Optional[float] = None
-                    ) -> Message: ...  # pragma: no cover
+    def ask_message(
+        self, message: Message, timeout: Optional[float] = None
+    ) -> Message: ...  # pragma: no cover
 
     def close(self) -> None: ...  # pragma: no cover
 
     # Utilities
-    def send(self,
-             receiver: Union[bytes, str],
-             conversation_id: Optional[bytes] = None,
-             data: Optional[Any] = None,
-             **kwargs) -> None:
+    def send(
+        self,
+        receiver: Union[bytes, str],
+        conversation_id: Optional[bytes] = None,
+        data: Optional[Any] = None,
+        **kwargs,
+    ) -> None:
         """Send a message based on kwargs."""
-        self.send_message(message=Message(
-            receiver=receiver, conversation_id=conversation_id, data=data, **kwargs
-        ))
+        self.send_message(
+            message=Message(receiver=receiver, conversation_id=conversation_id, data=data, **kwargs)
+        )
 
-    def ask(self, receiver: Union[bytes, str], conversation_id: Optional[bytes] = None,
-            data: Optional[Any] = None,
-            timeout: Optional[float] = None,
-            **kwargs) -> Message:
+    def ask(
+        self,
+        receiver: Union[bytes, str],
+        conversation_id: Optional[bytes] = None,
+        data: Optional[Any] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> Message:
         """Send a message based on kwargs and retrieve the response."""
-        return self.ask_message(message=Message(
-            receiver=receiver, conversation_id=conversation_id, data=data, **kwargs),
-            timeout=timeout)
+        return self.ask_message(
+            message=Message(
+                receiver=receiver, conversation_id=conversation_id, data=data, **kwargs
+            ),
+            timeout=timeout,
+        )
 
     def interpret_rpc_response(self, response_message: Message) -> Any:
         result = self.rpc_generator.get_result_from_response(response_message.payload[0])
@@ -97,11 +108,16 @@ class CommunicatorProtocol(Protocol):
         else:
             return result
 
-    def ask_rpc(self, receiver: Union[bytes, str], method: str, timeout: Optional[float] = None,
-                **kwargs) -> Any:
+    def ask_rpc(
+        self, receiver: Union[bytes, str], method: str, timeout: Optional[float] = None, **kwargs
+    ) -> Any:
         string = self.rpc_generator.build_request_str(method=method, **kwargs)
-        response = self.ask(receiver=receiver, data=string, message_type=MessageTypes.JSON,
-                            timeout=timeout)
+        response = self.ask(
+            receiver=receiver,
+            data=string,
+            message_type=MessageTypes.JSON,
+            timeout=timeout,
+        )
         return self.interpret_rpc_response(response)
 
 

--- a/pyleco/core/internal_protocols.py
+++ b/pyleco/core/internal_protocols.py
@@ -113,6 +113,7 @@ class CommunicatorProtocol(Protocol):
         receiver: Union[bytes, str],
         method: str,
         timeout: Optional[float] = None,
+        additional_payload: Optional[Iterable[bytes]] = None,
         extract_additional_payload: bool = False,
         **kwargs,
     ) -> Any:
@@ -122,6 +123,7 @@ class CommunicatorProtocol(Protocol):
             receiver=receiver,
             data=string,
             message_type=MessageTypes.JSON,
+            additional_payload=additional_payload,
             timeout=timeout,
         )
         return self.interpret_rpc_response(

--- a/pyleco/core/internal_protocols.py
+++ b/pyleco/core/internal_protocols.py
@@ -98,19 +98,25 @@ class CommunicatorProtocol(Protocol):
             timeout=timeout,
         )
 
-    def interpret_rpc_response(self, response_message: Message) -> Any:
+    def interpret_rpc_response(
+        self, response_message: Message, extract_additional_payload: bool = False
+    ) -> Any:
+        """Retrieve the return value of a RPC response message or its binary payload."""
         result = self.rpc_generator.get_result_from_response(response_message.payload[0])
-        if (
-            result is None
-            and len(response_message.payload) > 1
-        ):
+        if extract_additional_payload and result is None and len(response_message.payload) > 1:
             return response_message.payload[1]
         else:
             return result
 
     def ask_rpc(
-        self, receiver: Union[bytes, str], method: str, timeout: Optional[float] = None, **kwargs
+        self,
+        receiver: Union[bytes, str],
+        method: str,
+        timeout: Optional[float] = None,
+        extract_additional_payload: bool = False,
+        **kwargs,
     ) -> Any:
+        """Send a JSON-RPC request (with method \\**kwargs) and return the response value."""
         string = self.rpc_generator.build_request_str(method=method, **kwargs)
         response = self.ask(
             receiver=receiver,
@@ -118,7 +124,9 @@ class CommunicatorProtocol(Protocol):
             message_type=MessageTypes.JSON,
             timeout=timeout,
         )
-        return self.interpret_rpc_response(response)
+        return self.interpret_rpc_response(
+            response, extract_additional_payload=extract_additional_payload
+        )
 
 
 class SubscriberProtocol(Protocol):

--- a/pyleco/core/internal_protocols.py
+++ b/pyleco/core/internal_protocols.py
@@ -100,11 +100,11 @@ class CommunicatorProtocol(Protocol):
 
     def interpret_rpc_response(
         self, response_message: Message, extract_additional_payload: bool = False
-    ) -> Any:
-        """Retrieve the return value of a RPC response message or the additional payload."""
+    ) -> Union[Any, tuple[Any, list[bytes]]]:
+        """Retrieve the return value of a RPC response and optionally the additional payload."""
         result = self.rpc_generator.get_result_from_response(response_message.payload[0])
-        if extract_additional_payload and result is None and len(response_message.payload) > 1:
-            return response_message.payload[1:]
+        if extract_additional_payload:
+            return result, response_message.payload[1:]
         else:
             return result
 

--- a/pyleco/core/internal_protocols.py
+++ b/pyleco/core/internal_protocols.py
@@ -101,10 +101,10 @@ class CommunicatorProtocol(Protocol):
     def interpret_rpc_response(
         self, response_message: Message, extract_additional_payload: bool = False
     ) -> Any:
-        """Retrieve the return value of a RPC response message or its binary payload."""
+        """Retrieve the return value of a RPC response message or the additional payload."""
         result = self.rpc_generator.get_result_from_response(response_message.payload[0])
         if extract_additional_payload and result is None and len(response_message.payload) > 1:
-            return response_message.payload[1]
+            return response_message.payload[1:]
         else:
             return result
 

--- a/pyleco/core/internal_protocols.py
+++ b/pyleco/core/internal_protocols.py
@@ -88,7 +88,14 @@ class CommunicatorProtocol(Protocol):
             timeout=timeout)
 
     def interpret_rpc_response(self, response_message: Message) -> Any:
-        return self.rpc_generator.get_result_from_response(response_message.payload[0])
+        result = self.rpc_generator.get_result_from_response(response_message.payload[0])
+        if (
+            result is None
+            and len(response_message.payload) > 1
+        ):
+            return response_message.payload[1]
+        else:
+            return result
 
     def ask_rpc(self, receiver: Union[bytes, str], method: str, timeout: Optional[float] = None,
                 **kwargs) -> Any:

--- a/pyleco/core/leco_protocols.py
+++ b/pyleco/core/leco_protocols.py
@@ -105,7 +105,7 @@ class ExtendedComponentProtocol(ComponentProtocol, Protocol):
 
 
 class CoordinatorProtocol(ComponentProtocol, Protocol):
-    """A command protocol Coordinator"""
+    """A command protocol Coordinator."""
 
     def sign_in(self) -> None: ...
 

--- a/pyleco/core/message.py
+++ b/pyleco/core/message.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 from json import JSONDecodeError
-from typing import Any, Optional, Union
+from typing import Any, Iterable, Optional, Union
 
 
 from . import VERSION_B
@@ -64,6 +64,7 @@ class Message:
                  conversation_id: Optional[bytes] = None,
                  message_id: Optional[bytes] = None,
                  message_type: Union[MessageTypes, int] = MessageTypes.NOT_DEFINED,
+                 additional_payload: Optional[Iterable[bytes]] = None,
                  ) -> None:
         self.receiver = receiver.encode() if isinstance(receiver, str) else receiver
         self.sender = sender.encode() if isinstance(sender, str) else sender
@@ -81,6 +82,8 @@ class Message:
             self.payload = []
         else:
             self.payload = [serialize_data(data)]
+        if additional_payload is not None:
+            self.payload.extend(additional_payload)
 
     @classmethod
     def from_frames(cls, version: bytes, receiver: bytes, sender: bytes, header: bytes,
@@ -92,9 +95,8 @@ class Message:
             frames = socket.recv_multipart()
             message = Message.from_frames(*frames)
         """
-        inst = cls(receiver, sender, header=header)
+        inst = cls(receiver, sender, header=header, additional_payload=payload)
         inst.version = version
-        inst.payload = list(payload)
         return inst
 
     def to_frames(self) -> list[bytes]:

--- a/pyleco/directors/director.py
+++ b/pyleco/directors/director.py
@@ -24,7 +24,7 @@
 
 from __future__ import annotations
 import logging
-from typing import Any, Optional, Sequence, Union
+from typing import Any, Iterable, Optional, Sequence, Union
 
 from ..core.internal_protocols import CommunicatorProtocol
 from ..utils.communicator import Communicator
@@ -112,10 +112,23 @@ class Director:
         return params
 
     # Remote control synced
-    def ask_rpc(self, method: str, actor: Optional[Union[bytes, str]] = None, **kwargs) -> Any:
+    def ask_rpc(
+        self,
+        method: str,
+        actor: Optional[Union[bytes, str]] = None,
+        additional_payload: Optional[Iterable[bytes]] = None,
+        extract_additional_payload: bool = False,
+        **kwargs,
+    ) -> Any:
         """Remotely call the `method` procedure on the `actor` and return the return value."""
         receiver = self._actor_check(actor)
-        return self.communicator.ask_rpc(receiver=receiver, method=method, **kwargs)
+        return self.communicator.ask_rpc(
+            receiver=receiver,
+            method=method,
+            additional_payload=additional_payload,
+            extract_additional_payload=extract_additional_payload,
+            **kwargs,
+        )
 
     #   Component
     def get_rpc_capabilities(self, actor: Optional[Union[bytes, str]] = None) -> dict:

--- a/pyleco/directors/director.py
+++ b/pyleco/directors/director.py
@@ -177,23 +177,48 @@ class Director:
         return self.ask_rpc("call_action", action=action, actor=actor, **params)
 
     # Async methods: Just send, read later.
-    def send(self, actor: Optional[Union[bytes, str]] = None, data=None, **kwargs) -> bytes:
+    def send(
+        self,
+        actor: Optional[Union[bytes, str]] = None,
+        data=None,
+        additional_payload: Optional[Iterable[bytes]] = None,
+        **kwargs,
+    ) -> bytes:
         """Send a request and return the conversation_id."""
         actor = self._actor_check(actor)
         cid0 = generate_conversation_id()
-        self.communicator.send(actor, conversation_id=cid0, data=data, **kwargs)
+        self.communicator.send(
+            actor, conversation_id=cid0, data=data, additional_payload=additional_payload, **kwargs
+        )
         return cid0
 
-    def ask_rpc_async(self, method: str, actor: Optional[Union[bytes, str]] = None,
-                      **kwargs) -> bytes:
+    def ask_rpc_async(
+        self,
+        method: str,
+        actor: Optional[Union[bytes, str]] = None,
+        additional_payload: Optional[Iterable[bytes]] = None,
+        **kwargs,
+    ) -> bytes:
         """Send a rpc request, the response can be read later with :meth:`read_rpc_response`."""
         string = self.generator.build_request_str(method=method, **kwargs)
-        return self.send(actor=actor, data=string, message_type=MessageTypes.JSON)
+        return self.send(
+            actor=actor,
+            data=string,
+            message_type=MessageTypes.JSON,
+            additional_payload=additional_payload,
+        )
 
-    def read_rpc_response(self, conversation_id: Optional[bytes] = None, **kwargs) -> Any:
+    def read_rpc_response(
+        self,
+        conversation_id: Optional[bytes] = None,
+        extract_additional_payload: bool = False,
+        **kwargs,
+    ) -> Any:
         """Read the response value corresponding to a request with a certain `conversation_id`."""
         response_message = self.communicator.read_message(conversation_id=conversation_id, **kwargs)
-        return self.communicator.interpret_rpc_response(response_message=response_message)
+        return self.communicator.interpret_rpc_response(
+            response_message=response_message, extract_additional_payload=extract_additional_payload
+        )
 
     #   Actor
     def get_parameters_async(self, parameters: Union[str, Sequence[str]],

--- a/pyleco/directors/director.py
+++ b/pyleco/directors/director.py
@@ -88,10 +88,9 @@ class Director:
     # Message handling
     def ask_message(self, actor: Optional[Union[bytes, str]] = None,
                     data: Optional[Any] = None, **kwargs) -> Message:
-        cid0 = generate_conversation_id()
         actor = self._actor_check(actor)
         log.debug(f"Asking {actor!r} with message '{data}'.")
-        response = self.communicator.ask(actor, conversation_id=cid0, data=data, **kwargs)
+        response = self.communicator.ask(actor, data=data, **kwargs)
         log.debug(f"Data '{response.data}' received.")
         return response
 

--- a/pyleco/management/test_tasks/test_task.py
+++ b/pyleco/management/test_tasks/test_task.py
@@ -8,7 +8,7 @@ from time import sleep
 from pyleco.actors.actor import Actor
 
 
-class FakeInstrument:
+class FakeInstrument:  # pragma: no cover
     _prop1 = 5
 
     def __init__(self):

--- a/pyleco/test.py
+++ b/pyleco/test.py
@@ -23,7 +23,7 @@
 #
 
 from __future__ import annotations
-from typing import Any, Optional, Sequence, Union
+from typing import Any, Iterable, Optional, Sequence, Union
 
 from .core.message import Message
 from .core.internal_protocols import CommunicatorProtocol
@@ -219,14 +219,26 @@ class FakeDirector:
         super().__init__(**kwargs)
         self.remote_class = remote_class
 
-    def ask_rpc(self, method: str, actor: Optional[Union[bytes, str]] = None, **kwargs) -> Any:
+    def ask_rpc(
+        self,
+        method: str,
+        actor: Optional[Union[bytes, str]] = None,
+        additional_payload: Optional[Iterable[bytes]] = None,
+        extract_additional_payload: bool = False,
+        **kwargs,
+    ) -> Any:
         assert hasattr(self.remote_class, method), f"Remote class does not have method '{method}'."
         self.method = method
         self.kwargs = kwargs
         return self.return_value
 
-    def ask_rpc_async(self, method: str, actor: Optional[Union[bytes, str]] = None,
-                      **kwargs) -> bytes:
+    def ask_rpc_async(
+        self,
+        method: str,
+        actor: Optional[Union[bytes, str]] = None,
+        additional_payload: Optional[Iterable[bytes]] = None,
+        **kwargs,
+    ) -> bytes:
         assert hasattr(self.remote_class, method), f"Remote class does not have method '{method}'."
         self.method = method
         self.kwargs = kwargs

--- a/pyleco/utils/data_publisher.py
+++ b/pyleco/utils/data_publisher.py
@@ -25,7 +25,7 @@
 from __future__ import annotations
 import logging
 import pickle
-from typing import Any, Optional, Union
+from typing import Any, Iterable, Optional, Union
 
 import zmq
 
@@ -49,13 +49,15 @@ class DataPublisher:
 
     full_name: str
 
-    def __init__(self,
-                 full_name: str,
-                 host: str = "localhost",
-                 port: int = PROXY_RECEIVING_PORT,
-                 log: Optional[logging.Logger] = None,
-                 context: Optional[zmq.Context] = None,
-                 **kwargs) -> None:
+    def __init__(
+        self,
+        full_name: str,
+        host: str = "localhost",
+        port: int = PROXY_RECEIVING_PORT,
+        log: Optional[logging.Logger] = None,
+        context: Optional[zmq.Context] = None,
+        **kwargs,
+    ) -> None:
         if log is None:
             self.log = logging.getLogger(f"{__name__}.Publisher")
         else:
@@ -87,17 +89,22 @@ class DataPublisher:
         """Send a data protocol message."""
         self.socket.send_multipart(message.to_frames())
 
-    def send_data(self, data: Any,
-                  topic: Optional[Union[bytes, str]] = None,
-                  conversation_id: Optional[bytes] = None,
-                  message_type: Union[MessageTypes, int] = MessageTypes.NOT_DEFINED,
-                  ) -> None:
+    def send_data(
+        self,
+        data: Any,
+        topic: Optional[Union[bytes, str]] = None,
+        conversation_id: Optional[bytes] = None,
+        message_type: Union[MessageTypes, int] = MessageTypes.NOT_DEFINED,
+        additional_payload: Optional[Iterable[bytes]] = None,
+    ) -> None:
         """Send the `data` via the data protocol."""
-        message = DataMessage(topic=topic or self.full_name,
-                              data=data,
-                              conversation_id=conversation_id,
-                              message_type=message_type
-                              )
+        message = DataMessage(
+            topic=topic or self.full_name,
+            data=data,
+            conversation_id=conversation_id,
+            message_type=message_type,
+            additional_payload=additional_payload,
+        )
         self.send_message(message)
 
     def send_legacy(self, data: dict[str, Any]) -> None:

--- a/pyleco/utils/listener.py
+++ b/pyleco/utils/listener.py
@@ -139,6 +139,17 @@ class Listener:
         """
         self.message_handler.register_rpc_method(method=method, **kwargs)
 
+    def register_binary_rpc_method(
+        self, method: Callable, accept_binary_input: bool = False, **kwargs
+    ) -> None:
+        """Register a binary method for calling with the current message handler.
+
+        If you restart the listening, you have to register the method anew.
+        """
+        self.message_handler.register_binary_rpc_method(
+            method=method, accept_binary_input=accept_binary_input, **kwargs
+        )
+
     def stop_listen(self) -> None:
         """Stop the listener Thread."""
         try:

--- a/pyleco/utils/listener.py
+++ b/pyleco/utils/listener.py
@@ -22,10 +22,11 @@
 # THE SOFTWARE.
 #
 
+from __future__ import annotations
 import logging
 from threading import Thread, Event
 from time import sleep
-from typing import Callable, Optional
+from typing import Any, Callable, Optional, Union
 
 from ..core import PROXY_SENDING_PORT, COORDINATOR_PORT
 from .pipe_handler import PipeHandler, CommunicatorPipe
@@ -132,7 +133,7 @@ class Listener:
         kwargs.setdefault("timeout", self.timeout)
         return self.message_handler.get_communicator(**kwargs)
 
-    def register_rpc_method(self, method: Callable, **kwargs) -> None:
+    def register_rpc_method(self, method: Callable[..., Any], **kwargs) -> None:
         """Register a method for calling with the current message handler.
 
         If you restart the listening, you have to register the method anew.
@@ -140,14 +141,21 @@ class Listener:
         self.message_handler.register_rpc_method(method=method, **kwargs)
 
     def register_binary_rpc_method(
-        self, method: Callable, accept_binary_input: bool = False, **kwargs
+        self,
+        method: Callable[..., Union[Any, tuple[Any, list[bytes]]]],
+        accept_binary_input: bool = False,
+        return_binary_output: bool = False,
+        **kwargs,
     ) -> None:
         """Register a binary method for calling with the current message handler.
 
         If you restart the listening, you have to register the method anew.
         """
         self.message_handler.register_binary_rpc_method(
-            method=method, accept_binary_input=accept_binary_input, **kwargs
+            method=method,
+            accept_binary_input=accept_binary_input,
+            return_binary_output=return_binary_output,
+            **kwargs,
         )
 
     def stop_listen(self) -> None:

--- a/pyleco/utils/message_handler.py
+++ b/pyleco/utils/message_handler.py
@@ -172,7 +172,10 @@ class MessageHandler(BaseCommunicator, ExtendedComponentProtocol):
             def modified_method(*args, **kwargs):
                 return_value = method(*args, **kwargs)
                 return self._handle_possible_binary_return_value(return_value=return_value)
-
+        try:
+            modified_method.__doc__ += "\n(binary method)"  # type: ignore
+        except TypeError:
+            modified_method.__doc__ = "binary method"
         return modified_method
 
     def register_binary_rpc_method(

--- a/pyleco/utils/message_handler.py
+++ b/pyleco/utils/message_handler.py
@@ -163,8 +163,17 @@ class MessageHandler(BaseCommunicator, ExtendedComponentProtocol):
 
             @wraps(method)
             def modified_method(*args, **kwargs) -> ReturnValue:  # type: ignore
+                if args:
+                    args_l = list(args)
+                    if args_l[-1] is None:
+                        args_l[-1] = self.current_message.payload[1:]
+                    else:
+                        args_l.append(self.current_message.payload[1:])
+                    args = args_l  # type: ignore[assignment]
+                else:
+                    kwargs["additional_payload"] = self.current_message.payload[1:]
                 return_value = method(
-                    *args, additional_payload=self.current_message.payload[1:], **kwargs
+                    *args, **kwargs
                 )
                 return returner(return_value=return_value)  # type: ignore
         else:
@@ -193,7 +202,7 @@ class MessageHandler(BaseCommunicator, ExtendedComponentProtocol):
         """Register a method which accepts binary input and/or returns binary values.
 
         :param accept_binary_input: the method must accept the additional payload as an
-            `additional_payload` parameter.
+            `additional_payload=None` parameter (default value must be present as `None`!).
         :param return_binary_output: the method must return a tuple of a JSON-able python object
             (e.g. `None`) and of a list of bytes objects, to be sent as additional payload.
         """

--- a/pyleco/utils/message_handler.py
+++ b/pyleco/utils/message_handler.py
@@ -173,10 +173,14 @@ class MessageHandler(BaseCommunicator, ExtendedComponentProtocol):
             def modified_method(*args, **kwargs) -> ReturnValue:
                 return_value = method(*args, **kwargs)
                 return returner(return_value=return_value)  # type: ignore
+
+        doc_addition = (
+            f"(binary{' input' * accept_binary_input}{' output' * return_binary_output} method)"
+        )
         try:
-            modified_method.__doc__ += "\n(binary method)"  # type: ignore[operator]
+            modified_method.__doc__ += "\n" + doc_addition  # type: ignore[operator]
         except TypeError:
-            modified_method.__doc__ = "(binary method)"
+            modified_method.__doc__ = doc_addition
         return modified_method  # type: ignore
 
     def register_binary_rpc_method(

--- a/pyleco/utils/message_handler.py
+++ b/pyleco/utils/message_handler.py
@@ -329,9 +329,8 @@ class MessageHandler(BaseCommunicator, ExtendedComponentProtocol):
             conversation_id=message.conversation_id,
             message_type=MessageTypes.JSON,
             data=reply,
+            additional_payload=self.additional_response_payload
         )
-        if self.additional_response_payload is not None:
-            response.payload += self.additional_response_payload
         return response
 
     def handle_json_error(self, message: Message) -> None:

--- a/pyleco/utils/message_handler.py
+++ b/pyleco/utils/message_handler.py
@@ -66,6 +66,9 @@ class MessageHandler(BaseCommunicator, ExtendedComponentProtocol):
 
     name: str
 
+    current_message: Message
+    additional_response_payload: Optional[list[bytes]] = None
+
     def __init__(
         self,
         name: str,
@@ -251,6 +254,8 @@ class MessageHandler(BaseCommunicator, ExtendedComponentProtocol):
         self.send_message(response)
 
     def process_json_message(self, message: Message) -> Message:
+        self.current_message = message
+        self.additional_response_payload = None
         self.log.info(f"Handling commands of {message}.")
         reply = self.rpc.process_request(message.payload[0])
         response = Message(
@@ -259,6 +264,8 @@ class MessageHandler(BaseCommunicator, ExtendedComponentProtocol):
             message_type=MessageTypes.JSON,
             data=reply,
         )
+        if self.additional_response_payload is not None:
+            response.payload += self.additional_response_payload
         return response
 
     def handle_json_error(self, message: Message) -> None:

--- a/tests/acceptance_tests/test_director_actor.py
+++ b/tests/acceptance_tests/test_director_actor.py
@@ -72,7 +72,7 @@ def start_actor(event: threading.Event):
     actor = Actor("actor", FakeInstrument, port=PORT)
 
     def binary_method_manually() -> None:
-        """Receive binary data and return it."""
+        """Receive binary data and return it. Do all the binary things manually."""
         payload = actor.current_message.payload[1:]
         try:
             actor.additional_response_payload = [payload[0] * 2]
@@ -80,7 +80,7 @@ def start_actor(event: threading.Event):
             pass
 
     def binary_method_created(additional_payload: list[bytes]) -> tuple[None, list[bytes]]:
-        """Receive binary data and return it."""
+        """Receive binary data and return it. Create binary method by registering it."""
         return None, [additional_payload[0] * 2]
 
     actor.register_rpc_method(binary_method_manually)

--- a/tests/acceptance_tests/test_director_actor.py
+++ b/tests/acceptance_tests/test_director_actor.py
@@ -79,12 +79,14 @@ def start_actor(event: threading.Event):
         except IndexError:
             pass
 
-    def binary_method_created(additional_payload: list[bytes]) -> bytes:
+    def binary_method_created(additional_payload: list[bytes]) -> tuple[None, list[bytes]]:
         """Receive binary data and return it."""
-        return additional_payload[0] * 2
+        return None, [additional_payload[0] * 2]
 
     actor.register_rpc_method(binary_method_manually)
-    actor.register_binary_rpc_method(binary_method_created, accept_binary_input=True)
+    actor.register_binary_rpc_method(
+        binary_method_created, accept_binary_input=True, return_binary_output=True
+    )
     actor.connect()
     actor.rpc.method()(actor.device.triple)
     actor.register_device_method(actor.device.triple)

--- a/tests/acceptance_tests/test_director_actor.py
+++ b/tests/acceptance_tests/test_director_actor.py
@@ -148,4 +148,4 @@ def test_device_method_via_rpc(director: Director):
 def test_binary_data_transfer(director: Director):
     assert director.ask_rpc(
         method="binary_method", additional_payload=[b"123"], extract_additional_payload=True
-    ) == b"123123"
+    ) == [b"123123"]

--- a/tests/acceptance_tests/test_director_actor.py
+++ b/tests/acceptance_tests/test_director_actor.py
@@ -148,4 +148,4 @@ def test_device_method_via_rpc(director: Director):
 def test_binary_data_transfer(director: Director):
     assert director.ask_rpc(
         method="binary_method", additional_payload=[b"123"], extract_additional_payload=True
-    ) == [b"123123"]
+    ) == (None, [b"123123"])

--- a/tests/acceptance_tests/test_director_actor.py
+++ b/tests/acceptance_tests/test_director_actor.py
@@ -69,6 +69,16 @@ class FakeInstrument:
 
 def start_actor(event: threading.Event):
     actor = Actor("actor", FakeInstrument, port=PORT)
+
+    def binary_method() -> None:
+        """Receive binary data and return it."""
+        payload = actor.current_message.payload[1:]
+        try:
+            actor.additional_response_payload = [payload[0] * 2]
+        except IndexError:
+            pass
+
+    actor.register_rpc_method(binary_method)
     actor.connect()
     actor.rpc.method()(actor.device.triple)
     actor.register_device_method(actor.device.triple)
@@ -133,3 +143,9 @@ def test_method_via_rpc2(director: Director):
 
 def test_device_method_via_rpc(director: Director):
     assert director.ask_rpc(method="device.triple", factor=5) == 15
+
+
+def test_binary_data_transfer(director: Director):
+    assert director.ask_rpc(
+        method="binary_method", additional_payload=[b"123"], extract_additional_payload=True
+    ) == b"123123"

--- a/tests/core/test_data_message.py
+++ b/tests/core/test_data_message.py
@@ -54,6 +54,14 @@ class TestDataMessageInit:
         with pytest.raises(ValueError, match="header"):
             DataMessage(topic="topic", header=b"whatever", **{key: value})
 
+    def test_additional_payload(self):
+        message = DataMessage("topic", data=b"0", additional_payload=[b"1", b"2"])
+        assert message.payload == [b"0", b"1", b"2"]
+
+    def test_additional_payload_without_data(self):
+        message = DataMessage("topic", additional_payload=[b"1", b"2"])
+        assert message.payload == [b"1", b"2"]
+
 
 def test_data_message_str_topic():
     assert DataMessage(topic="topic").topic == b"topic"

--- a/tests/core/test_internal_protocols.py
+++ b/tests/core/test_internal_protocols.py
@@ -88,11 +88,12 @@ class Test_interpret_rpc_response:
         message = Message(
             receiver="rec",
             data={"jsonrpc": "2.0", "result": None, "id": 7},
-            additional_payload=[b"abcd"],
+            additional_payload=[b"abcd", b"efgh"],
         )
-        assert (
-            communicator.interpret_rpc_response(message, extract_additional_payload=True) == b"abcd"
-        )
+        assert communicator.interpret_rpc_response(message, extract_additional_payload=True) == [
+            b"abcd",
+            b"efgh",
+        ]
 
     def test_ignore_additional_payload_if_not_desired(self, communicator: FakeCommunicator):
         message = Message(

--- a/tests/core/test_internal_protocols.py
+++ b/tests/core/test_internal_protocols.py
@@ -90,10 +90,13 @@ class Test_interpret_rpc_response:
             data={"jsonrpc": "2.0", "result": None, "id": 7},
             additional_payload=[b"abcd", b"efgh"],
         )
-        assert communicator.interpret_rpc_response(message, extract_additional_payload=True) == [
-            b"abcd",
-            b"efgh",
-        ]
+        assert communicator.interpret_rpc_response(message, extract_additional_payload=True) == (
+            None,
+            [
+                b"abcd",
+                b"efgh",
+            ],
+        )
 
     def test_ignore_additional_payload_if_not_desired(self, communicator: FakeCommunicator):
         message = Message(
@@ -110,7 +113,10 @@ class Test_interpret_rpc_response:
             receiver="rec",
             data={"jsonrpc": "2.0", "result": None, "id": 7},
         )
-        assert communicator.interpret_rpc_response(message, extract_additional_payload=True) is None
+        assert communicator.interpret_rpc_response(message, extract_additional_payload=True) == (
+            None,
+            [],
+        )
 
     def test_json_value_overrides_binary(self, communicator: FakeCommunicator):
         message = Message(
@@ -118,7 +124,10 @@ class Test_interpret_rpc_response:
             data={"jsonrpc": "2.0", "result": 6, "id": 7},
             additional_payload=[b"abcd"],
         )
-        assert communicator.interpret_rpc_response(message, extract_additional_payload=True) == 6
+        assert communicator.interpret_rpc_response(message, extract_additional_payload=True) == (
+            6,
+            [b"abcd"],
+        )
 
 
 class Test_ask_rpc:

--- a/tests/core/test_internal_protocols.py
+++ b/tests/core/test_internal_protocols.py
@@ -85,14 +85,39 @@ class Test_interpret_rpc_response:
             communicator.interpret_rpc_response(message)
 
     def test_json_binary_response(self, communicator: FakeCommunicator):
-        message = Message(receiver="rec", data={"jsonrpc": "2.0", "result": None, "id": 7})
-        message.payload.append(b"abcd")
-        assert communicator.interpret_rpc_response(message) == b"abcd"
+        message = Message(
+            receiver="rec",
+            data={"jsonrpc": "2.0", "result": None, "id": 7},
+            additional_payload=[b"abcd"],
+        )
+        assert (
+            communicator.interpret_rpc_response(message, extract_additional_payload=True) == b"abcd"
+        )
+
+    def test_ignore_additional_payload_if_not_desired(self, communicator: FakeCommunicator):
+        message = Message(
+            receiver="rec",
+            data={"jsonrpc": "2.0", "result": None, "id": 7},
+            additional_payload=[b"abcd"],
+        )
+        assert (
+            communicator.interpret_rpc_response(message, extract_additional_payload=False) is None
+        )
+
+    def test_without_additional_payload_return_None(self, communicator: FakeCommunicator):
+        message = Message(
+            receiver="rec",
+            data={"jsonrpc": "2.0", "result": None, "id": 7},
+        )
+        assert communicator.interpret_rpc_response(message, extract_additional_payload=True) is None
 
     def test_json_value_overrides_binary(self, communicator: FakeCommunicator):
-        message = Message(receiver="rec", data={"jsonrpc": "2.0", "result": 6, "id": 7})
-        message.payload.append(b"abcd")
-        assert communicator.interpret_rpc_response(message) == 6
+        message = Message(
+            receiver="rec",
+            data={"jsonrpc": "2.0", "result": 6, "id": 7},
+            additional_payload=[b"abcd"],
+        )
+        assert communicator.interpret_rpc_response(message, extract_additional_payload=True) == 6
 
 
 class Test_ask_rpc:

--- a/tests/core/test_internal_protocols.py
+++ b/tests/core/test_internal_protocols.py
@@ -84,6 +84,16 @@ class Test_interpret_rpc_response:
         with pytest.raises(JSONRPCError):
             communicator.interpret_rpc_response(message)
 
+    def test_json_binary_response(self, communicator: FakeCommunicator):
+        message = Message(receiver="rec", data={"jsonrpc": "2.0", "result": None, "id": 7})
+        message.payload.append(b"abcd")
+        assert communicator.interpret_rpc_response(message) == b"abcd"
+
+    def test_json_value_overrides_binary(self, communicator: FakeCommunicator):
+        message = Message(receiver="rec", data={"jsonrpc": "2.0", "result": 6, "id": 7})
+        message.payload.append(b"abcd")
+        assert communicator.interpret_rpc_response(message) == 6
+
 
 class Test_ask_rpc:
     response = Message(receiver="communicator", sender="rec", conversation_id=cid,

--- a/tests/core/test_internal_protocols.py
+++ b/tests/core/test_internal_protocols.py
@@ -147,6 +147,27 @@ class Test_ask_rpc:
                                                      "params": {'par1': 5},
                                                  })]
 
+    def test_sent_with_additional_payload(self, communicator_asked: FakeCommunicator):
+        communicator_asked.ask_rpc(
+            receiver="rec", method="test_method", par1=5, additional_payload=[b"12345"]
+        )
+        sent = communicator_asked._s[0]
+        assert communicator_asked._s == [
+            Message(
+                receiver="rec",
+                sender="communicator",
+                conversation_id=sent.conversation_id,
+                message_type=MessageTypes.JSON,
+                data={
+                    "jsonrpc": "2.0",
+                    "method": "test_method",
+                    "id": 1,
+                    "params": {"par1": 5},
+                },
+                additional_payload=[b"12345"],
+            )
+        ]
+
     def test_read(self, communicator_asked: FakeCommunicator):
         result = communicator_asked.ask_rpc(receiver="rec", method="test_method", par1=5)
         assert result == 5

--- a/tests/core/test_internal_protocols.py
+++ b/tests/core/test_internal_protocols.py
@@ -108,7 +108,7 @@ class Test_interpret_rpc_response:
             communicator.interpret_rpc_response(message, extract_additional_payload=False) is None
         )
 
-    def test_without_additional_payload_return_None(self, communicator: FakeCommunicator):
+    def test_without_additional_payload_return_empty_list(self, communicator: FakeCommunicator):
         message = Message(
             receiver="rec",
             data={"jsonrpc": "2.0", "result": None, "id": 7},
@@ -118,7 +118,7 @@ class Test_interpret_rpc_response:
             [],
         )
 
-    def test_json_value_overrides_binary(self, communicator: FakeCommunicator):
+    def test_json_value_and_binary_payload(self, communicator: FakeCommunicator):
         message = Message(
             receiver="rec",
             data={"jsonrpc": "2.0", "result": 6, "id": 7},

--- a/tests/core/test_message.py
+++ b/tests/core/test_message.py
@@ -84,6 +84,14 @@ class Test_Message_create_message:
         message = Message(b"rec", data="some string")
         assert message.payload[0] == b"some string"
 
+    def test_additional_binary_data(self):
+        message = Message(b"rec", data=b"0", additional_payload=[b"1", b"2"])
+        assert message.payload == [b"0", b"1", b"2"]
+
+    def test_additional_payload_without_data(self):
+        message = Message(b"rec", additional_payload=[b"1", b"2"])
+        assert message.payload == [b"1", b"2"]
+
     @pytest.mark.parametrize("key, value", (("conversation_id", b"content"),
                                             ("message_id", b"mid"),
                                             ("message_type", 7),

--- a/tests/directors/test_director.py
+++ b/tests/directors/test_director.py
@@ -147,9 +147,10 @@ def test_read_binary_rpc_response(director: Director):
             additional_payload=[b"123"],
         )
     ]
-    assert director.read_rpc_response(conversation_id=cid, extract_additional_payload=True) == [
-        b"123"
-    ]
+    assert director.read_rpc_response(conversation_id=cid, extract_additional_payload=True) == (
+        None,
+        [b"123"],
+    )
 
 
 def test_get_properties_async(director: Director):

--- a/tests/directors/test_director.py
+++ b/tests/directors/test_director.py
@@ -77,6 +77,19 @@ class Test_actor_check:
         assert director._actor_check("") == "actor"
 
 
+def test_ask_message(director: Director):
+    rec = Message("director", "actor", conversation_id=cid)
+    director.communicator._r = [rec]  # type: ignore
+    result = director.ask_message()
+    assert result == rec
+    sent = director.communicator._s[0]  # type: ignore
+    assert sent == Message(
+        "actor",
+        "director",
+        conversation_id=cid,
+    )
+
+
 def test_get_rpc_capabilities(director: Director):
     data = {"name": "actor", "methods": []}
     director.communicator._r = [  # type: ignore

--- a/tests/directors/test_director.py
+++ b/tests/directors/test_director.py
@@ -136,6 +136,22 @@ def test_read_rpc_response(director: Director):
     assert director.read_rpc_response(conversation_id=cid) == 7.5
 
 
+def test_read_binary_rpc_response(director: Director):
+    director.communicator._r = [  # type: ignore
+        Message(
+            "director",
+            "actor",
+            conversation_id=cid,
+            message_type=MessageTypes.JSON,
+            data={"id": 1, "result": None, "jsonrpc": "2.0"},
+            additional_payload=[b"123"],
+        )
+    ]
+    assert director.read_rpc_response(conversation_id=cid, extract_additional_payload=True) == [
+        b"123"
+    ]
+
+
 def test_get_properties_async(director: Director):
     properties = ["a", "some"]
     cid = director.get_parameters_async(parameters=properties)

--- a/tests/utils/test_data_publisher.py
+++ b/tests/utils/test_data_publisher.py
@@ -59,6 +59,13 @@ def test_call_publisher_sends(publisher: DataPublisher):
     assert message.payload[0] == b"data"
 
 
+def test_send_data(publisher: DataPublisher):
+    publisher.send_data(
+        data=b"data", topic=b"topic", conversation_id=b"cid", additional_payload=[b"1"]
+    )
+    assert publisher.socket._s == [[b"topic", b"cid\x00", b"data", b"1"]]
+
+
 def test_send_message(publisher: DataPublisher):
     message = DataMessage.from_frames(b"topic", b"header", b"data")
     publisher.send_message(message=message)

--- a/tests/utils/test_message_handler.py
+++ b/tests/utils/test_message_handler.py
@@ -571,15 +571,31 @@ class Test_generate_binary_method:
         assert modified_binary_method.__name__ == binary_method.__name__
 
     def test_docstring(self, modified_binary_method, binary_method):
-        assert modified_binary_method.__doc__ == binary_method.__doc__ + "\n(binary method)"
+        doc_addition = (
+            "(binary input output method)"
+            if self._accept_binary_input
+            else "(binary output method)"
+        )
+        assert modified_binary_method.__doc__ == binary_method.__doc__ + "\n" + doc_addition
 
-    def test_docstring_without_original_docstring(self, handler: MessageHandler):
+    @pytest.mark.parametrize(
+        "input, output, string",
+        (
+            (False, False, "(binary method)"),
+            (True, False, "(binary input method)"),
+            (False, True, "(binary output method)"),
+            (True, True, "(binary input output method)"),
+        ),
+    )
+    def test_docstring_without_original_docstring(
+        self, handler: MessageHandler, input, output, string
+    ):
         def binary_method(additional_payload):
             return 7
         mod = handler._generate_binary_capable_method(
-            binary_method, accept_binary_input=True, return_binary_output=False
+            binary_method, accept_binary_input=input, return_binary_output=output
         )
-        assert mod.__doc__ == "(binary method)"
+        assert mod.__doc__ == string
 
     def test_annotation(self, modified_binary_method, binary_method):
         assert modified_binary_method.__annotations__ == binary_method.__annotations__

--- a/tests/utils/test_message_handler.py
+++ b/tests/utils/test_message_handler.py
@@ -540,36 +540,19 @@ class Test_process_json_message_with_binary:
         assert response.data == {"jsonrpc": "2.0", "id": 8, "result": None}
 
 
-@pytest.mark.parametrize(
-    "return_value",
-    ("asfd", 123.456, ["abc", 3, 9], 90),
-)
-def test_handle_possible_binary_return_value_unmodified_json(handler: MessageHandler, return_value):
-    result = handler._handle_possible_binary_return_value(return_value)
-    assert result == return_value
-    assert handler.additional_response_payload is None
-
-@pytest.mark.parametrize(
-    "return_value, payload",
-    (
-        (b"abcd", [b"abcd"]),
-        ([b"ab"], [b"ab"]),
-        ([b"ab", b"cd"], [b"ab", b"cd"]),
-    ),
-)
-def test_handle_possible_binary_return_value_with_binary(
-    handler: MessageHandler, return_value, payload
-):
-    result = handler._handle_possible_binary_return_value(return_value)
+def test_handle_binary_return_value(handler: MessageHandler):
+    payload = [b"abc", b"def"]
+    result = handler._handle_binary_return_value((None, payload))
     assert result is None
     assert handler.additional_response_payload == payload
+
 
 class Test_generate_binary_method:
     @pytest.fixture
     def binary_method(self):
-        def binary_method(index: int, additional_payload: list[bytes]) -> bytes:
+        def binary_method(index: int, additional_payload: list[bytes]) -> tuple[None, list[bytes]]:
             """Docstring of binary method."""
-            return additional_payload[index]
+            return None, [additional_payload[index]]
         return binary_method
 
     @pytest.fixture(params=(True, False))
@@ -578,7 +561,9 @@ class Test_generate_binary_method:
             "rec", "send", data=b"", additional_payload=[b"0", b"1", b"2", b"3"]
         )
         self._accept_binary_input = abi = request.param
-        mod = handler._generate_binary_capable_method(binary_method, accept_binary_input=abi)
+        mod = handler._generate_binary_capable_method(
+            binary_method, accept_binary_input=abi, return_binary_output=True
+        )
         self.handler = handler
         return mod
 
@@ -587,6 +572,14 @@ class Test_generate_binary_method:
 
     def test_docstring(self, modified_binary_method, binary_method):
         assert modified_binary_method.__doc__ == binary_method.__doc__ + "\n(binary method)"
+
+    def test_docstring_without_original_docstring(self, handler: MessageHandler):
+        def binary_method(additional_payload):
+            return 7
+        mod = handler._generate_binary_capable_method(
+            binary_method, accept_binary_input=True, return_binary_output=False
+        )
+        assert mod.__doc__ == "(binary method)"
 
     def test_annotation(self, modified_binary_method, binary_method):
         assert modified_binary_method.__annotations__ == binary_method.__annotations__
@@ -606,6 +599,16 @@ class Test_generate_binary_method:
         else:
             assert modified_binary_method(1, [b"0", b"1", b"2", b"3"]) is None
         assert self.handler.additional_response_payload == [b"1"]
+
+    def test_no_binary_return(self, handler: MessageHandler):
+        handler.current_message = Message("rec", "send", data=b"", additional_payload=[b"0"])
+
+        def binary_method(additional_payload = None):
+            return 7
+        mod = handler._generate_binary_capable_method(
+            binary_method, accept_binary_input=True, return_binary_output=False
+        )
+        assert mod() == 7
 
 
 class Test_listen:

--- a/tests/utils/test_message_handler.py
+++ b/tests/utils/test_message_handler.py
@@ -453,8 +453,12 @@ class Test_read_and_handle_message:
     def test_handle_undecodable_message(self, handler: MessageHandler,
                                         caplog: pytest.LogCaptureFixture):
         """An invalid message should not cause the message handler to crash."""
-        message = Message(b"N3.handler", b"N3.COORDINATOR", message_type=MessageTypes.JSON)
-        message.payload = [b"()"]
+        message = Message(
+            b"N3.handler",
+            b"N3.COORDINATOR",
+            message_type=MessageTypes.JSON,
+            additional_payload=[b"()"],
+        )
         handler.socket._r = [message.to_frames()]  # type: ignore
         handler.read_and_handle_message()
         assert caplog.records[-1].msg.startswith("Could not decode")
@@ -526,8 +530,9 @@ class Test_process_json_message_with_binary:
         assert handler_b.additional_response_payload is None
 
     def test_binary_payload_available(self, handler_b: MessageHandler):
-        m_in = Message("abc", data=self.data, message_type=MessageTypes.JSON)
-        m_in.payload.append(b"def")
+        m_in = Message(
+            "abc", data=self.data, message_type=MessageTypes.JSON, additional_payload=[b"def"]
+        )
         self.payload_out = []
         handler_b.process_json_message(m_in)
         assert self.payload_in == [b"def"]
@@ -616,7 +621,7 @@ class Test_generate_binary_method:
             assert modified_binary_method(1, [b"0", b"1", b"2", b"3"]) is None
         assert self.handler.additional_response_payload == [b"1"]
 
-    def test_no_binary_return(self, handler: MessageHandler):
+    def test_binary_input_from_message(self, handler: MessageHandler):
         handler.current_message = Message("rec", "send", data=b"", additional_payload=[b"0"])
 
         def binary_method(additional_payload = None):

--- a/tests/utils/test_message_handler.py
+++ b/tests/utils/test_message_handler.py
@@ -586,7 +586,7 @@ class Test_generate_binary_method:
         assert modified_binary_method.__name__ == binary_method.__name__
 
     def test_docstring(self, modified_binary_method, binary_method):
-        assert modified_binary_method.__doc__ == binary_method.__doc__
+        assert modified_binary_method.__doc__ == binary_method.__doc__ + "\n(binary method)"
 
     def test_annotation(self, modified_binary_method, binary_method):
         assert modified_binary_method.__annotations__ == binary_method.__annotations__


### PR DESCRIPTION
Implements the transport of binary data in additional frames, related to _How to transmit binary data_ (https://github.com/pymeasure/leco-protocol/issues/65).

Idea:
- First payload frame is JSON
- Second (and more) frame are binary

Implementation ideas.
- `MessageHandler` offers the whole message for the rpc handler and adds the additional frames afterwards
- Communicator can return the bytes
- Communicator (and Director) can send bytes in a rpc request

Open questions:
- [ ] Should a message with binary data contain a different message type?
- [ ] If not, how to know, whether the binary data is the desired response instead of the json response?
      A return value of `None` with additional payload frames is a strong indicator, but not exclusive to this scenario. Is it sufficient?
- [ ] The `additional_payload` of the Message: what to do, if there is no data defined: should there be an empty first data frame before the additional, or is the additional_payload the whole payload?