### PR TITLE
Fix ruff action

### DIFF
--- a/.github/workflows/pyleco_CI.yml
+++ b/.github/workflows/pyleco_CI.yml
@@ -28,7 +28,7 @@ jobs:
           python --version
           micromamba info
       - name: Lint with ruff
-        uses: chartboost/ruff-action@v1
+        uses: astral-sh/ruff-action@v1
         with:
           version: 0.4.10  # ruff-action@v1 is broken in regard to ruff 0.5.0
           args: --extend-select=E9,F63,F7,F82 --show-source


### PR DESCRIPTION
Updates ruff action to maintained version, see #92  as currently used one is not maintained anymore.

Maybe fixes the broken dependency on most current ruff, #92.
