### PR TITLE
Update ruff configuration for pipeline

### DIFF
--- a/.github/workflows/pyleco_CI.yml
+++ b/.github/workflows/pyleco_CI.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Lint with ruff
         uses: astral-sh/ruff-action@v3
         with:
-          args: --extend-select=E9,F63,F7,F82 --show-source
+          args: "check --extend-select=E9,F63,F7,F82 --output-format full"
       - uses: ammaraskar/sphinx-problem-matcher@master
       - name: Generate docs
         if: always()  # run even if the previous step failed


### PR DESCRIPTION
With the new ruff action, also a new ruff version is needed, which requires a new configuration.