### PR TITLE
Make Coordinator send a notification after coordinator sign in instead of a request

### DIFF
--- a/pyleco/utils/coordinator_utils.py
+++ b/pyleco/utils/coordinator_utils.py
@@ -36,7 +36,7 @@ from ..core.message import Message, MessageTypes
 from ..core.serialization import deserialize_data
 from ..json_utils.errors import NOT_SIGNED_IN, DUPLICATE_NAME
 from ..json_utils.rpc_generator import RPCGenerator
-from ..json_utils.json_objects import ErrorResponse, Request, JsonRpcBatch, ParamsRequest
+from ..json_utils.json_objects import ErrorResponse, Request, JsonRpcBatch, ParamsNotification
 
 
 log = logging.getLogger(__name__)
@@ -334,11 +334,10 @@ class Directory:
                 message_type=MessageTypes.JSON,
                 data=JsonRpcBatch(
                     [
-                        ParamsRequest(
-                            id=2, method="add_nodes", params=dict(nodes=self.get_nodes_str_dict())
+                        ParamsNotification(
+                            method="add_nodes", params=dict(nodes=self.get_nodes_str_dict())
                         ),
-                        ParamsRequest(
-                            id=3,
+                        ParamsNotification(
                             method="record_components",
                             params=dict(components=self.get_component_names()),
                         ),

--- a/tests/utils/test_coordinator_utils.py
+++ b/tests/utils/test_coordinator_utils.py
@@ -27,8 +27,8 @@ import pytest
 from pyleco.test import FakeContext
 from pyleco.core.message import Message, MessageTypes
 from pyleco.json_utils.errors import NOT_SIGNED_IN, DUPLICATE_NAME, INVALID_REQUEST
-from pyleco.json_utils.json_objects import Request, ResultResponse, ErrorResponse, ParamsRequest,\
-    JsonRpcBatch
+from pyleco.json_utils.json_objects import Request, ResultResponse, ErrorResponse,\
+    JsonRpcBatch, ParamsNotification
 from pyleco.utils.coordinator_utils import CommunicationError, ZmqNode, ZmqMultiSocket, Node,\
     Directory, FakeNode
 
@@ -352,8 +352,7 @@ class Test_finish_sign_in_to_remote:
                 b"N1.COORDINATOR",
                 data=JsonRpcBatch(
                     [
-                        ParamsRequest(
-                            2,
+                        ParamsNotification(
                             method="add_nodes",
                             params={
                                 "nodes": {
@@ -363,8 +362,8 @@ class Test_finish_sign_in_to_remote:
                                 }
                             },
                         ),
-                        ParamsRequest(
-                            3, method="record_components", params={"components": ["send", "rec"]}
+                        ParamsNotification(
+                            method="record_components", params={"components": ["send", "rec"]}
                         ),
                     ]
                 ),


### PR DESCRIPTION
This makes it easier, as the other Coordinator might not have a possibility to send the response yet.